### PR TITLE
Ensure that the PID file is always closed

### DIFF
--- a/jibri-xmpp-client/app.py
+++ b/jibri-xmpp-client/app.py
@@ -88,9 +88,8 @@ def writePidFile():
     global pidfile
     try:
         pid = str(os.getpid())
-        f = open(pidfile, 'w')
-        f.write(pid)
-        f.close()
+        with open(pidfile, 'w') as f:
+            f.write(pid)
         atexit.register(deletePidFile)
     except FileNotFoundError as e:
         logging.warn("Unable to write pidfile: %s, %s"%(pidfile, e))


### PR DESCRIPTION
Fixes a minor resource leak where the PID file could end up not being closed. If this were to happen, the program probably would have crashed anyways, so it wouldn't matter, but since we don't know what kind of error handling is happening outside of the `writePidFile` function (that might be catching the error and not terminating the program) we should ensure that the file handle gets closed anyways.