### PR TITLE
Broken link for debian control file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo chmod 0755 /usr/local/bin/chromedriver
 ```
 
 ### Miscellaneous required tools
-See the debian [control file](resources/debian-package-jibri/DEBIAN/control) for the dependencies that are required.
+See the debian [control file](debian/jibri/DEBIAN/control) for the dependencies that are required.
 
 ### Jitsi Debian Repository
 The latest Jibri packages can be found in the unstable repository on downloads.jitsi.org.


### PR DESCRIPTION
In README.md, the link for debian control file specified under [Miscellaneous required tools](https://github.com/jitsi/jibri/blob/master/README.md#miscellaneous-required-tools) section is broken (404).

Perhaps the working link is [this](https://github.com/jitsi/jibri/blob/master/debian/jibri/DEBIAN/control)?