### PR TITLE
fix an issue with restarting ffmpeg (without adding another bug this

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/impl/AbstractFfmpegExecutor.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/impl/AbstractFfmpegExecutor.kt
@@ -28,6 +28,7 @@ import org.jitsi.jibri.util.extensions.debug
 import org.jitsi.jibri.util.extensions.error
 import org.jitsi.jibri.util.logStream
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 
@@ -41,6 +42,7 @@ abstract class AbstractFfmpegExecutor(private val processBuilder: ProcessBuilder
     private val logger = Logger.getLogger(AbstractFfmpegExecutor::class.qualifiedName)
     private val ffmpegOutputLogger = Logger.getLogger("ffmpeg")
     private val executor = Executors.newSingleThreadExecutor(NameableThreadFactory("AbstractFfmpegExecutor"))
+    private var processLoggerTask: Future<*>? = null
     /**
      * The currently active (if any) Ffmpeg process
      */
@@ -67,19 +69,14 @@ abstract class AbstractFfmpegExecutor(private val processBuilder: ProcessBuilder
         return currentFfmpegProc?.let {
             logger.info("Starting ffmpeg with command $command")
             it.start()
-            logStream(it.getOutput(), ffmpegOutputLogger, executor)
+            processLoggerTask = logStream(it.getOutput(), ffmpegOutputLogger, executor)
             true
         } ?: run {
             false
         }
     }
 
-    override fun getExitCode(): Int? {
-        if (currentFfmpegProc?.isAlive == true) {
-            return null
-        }
-        return currentFfmpegProc?.exitValue()
-    }
+    override fun getExitCode(): Int? = if (currentFfmpegProc?.isAlive == true) null else currentFfmpegProc?.exitValue()
 
     override fun isHealthy(): Boolean {
         return currentFfmpegProc?.let {
@@ -108,7 +105,6 @@ abstract class AbstractFfmpegExecutor(private val processBuilder: ProcessBuilder
     }
 
     override fun stopFfmpeg() {
-        executor.shutdown()
         logger.info("Stopping ffmpeg process")
         currentFfmpegProc?.apply {
             stop()
@@ -118,6 +114,7 @@ abstract class AbstractFfmpegExecutor(private val processBuilder: ProcessBuilder
                 destroyForcibly()
             }
         }
+        processLoggerTask?.get()
         logger.info("Ffmpeg exited with value ${currentFfmpegProc?.exitValue()}")
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
@@ -147,6 +147,7 @@ class FileRecordingJibriService(private val fileRecordingParams: FileRecordingPa
                 logger.error("Giving up on restarting the capturer")
                 publishStatus(JibriServiceStatus.ERROR)
             } else {
+                logger.info("Trying to restart capturer")
                 numRestarts++
                 // Re-create the sink here because we want a new filename
                 //TODO: we can run into an issue here where this takes a while and the monitor task runs again

--- a/src/main/kotlin/org/jitsi/jibri/util/ProcessMonitor.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/ProcessMonitor.kt
@@ -17,6 +17,7 @@
 
 package org.jitsi.jibri.util
 
+import org.jitsi.jibri.util.extensions.debug
 import org.jitsi.jibri.util.extensions.error
 import java.util.logging.Logger
 
@@ -39,12 +40,13 @@ class ProcessMonitor(
      * [processToMonitor] (or null, if there isn't one)
      */
     override fun run() {
+        logger.debug("ProcessMonitor checking process health")
         try {
             if (!processToMonitor.isHealthy()) {
                 processUnhealthyCallback(processToMonitor.getExitCode())
             }
         } catch (t: Throwable) {
-            logger.error("Error while determining process health: $t")
+            logger.error("Error while determining process health", t)
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/util/ProcessWrapper.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/ProcessWrapper.kt
@@ -88,8 +88,10 @@ abstract class ProcessWrapper<out StatusType>(
     fun waitFor(timeout: Long, unit: TimeUnit): Boolean = process.waitFor(timeout, unit)
 
     fun stop() {
-        tail.stop()
-        tee.stop()
+        // Note that we specifically do NOT call stop on tee or tail here
+        // because we want them to read everything available from the
+        // process' inputstream. Once it's done, they'll read
+        // the EOF and close things up correctly
         val pid = pid(process)
         Runtime.getRuntime().exec("kill -s SIGINT $pid")
     }

--- a/src/main/kotlin/org/jitsi/jibri/util/extensions/LoggerExts.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/extensions/LoggerExts.kt
@@ -37,6 +37,15 @@ inline fun Logger.error(msg: String) {
     this.log(Level.SEVERE, msg)
 }
 
+inline fun Logger.error(msg: String, t: Throwable) {
+    val sb = StringBuffer()
+    sb.append("$msg: $t").append(" with stack: \n")
+    for (stackElement in t.stackTrace) {
+        sb.append(stackElement.toString()).append("\n")
+    }
+    error(sb.toString())
+}
+
 inline fun Logger.debug(msg: String) {
     this.fine(msg)
 }


### PR DESCRIPTION
time)

was shutting down the executor, which means it will reject all future
tasks we try to submit to it.  since we use the same ffmpegexecutor
instance on restart, this was breaking restarting ffmpeg.  Also make
sure we let Tee run to its natural completion, so we get a proper
closing of all of its downstream branches.