### PR TITLE
fix a bug in passing sink options

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/Commands.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/Commands.kt
@@ -32,7 +32,7 @@ fun getFfmpegCommandLinux(ffmpegExecutorParams: FfmpegExecutorParams, sink: Sink
         "-i", "hw:0,1,0",
         "-acodec", "aac", "-strict", "-2", "-ar", "44100",
         "-c:v", "libx264", "-preset", ffmpegExecutorParams.videoEncodePreset,
-        sink.options, "-pix_fmt", "yuv420p", "-r", ffmpegExecutorParams.framerate.toString(),
+        *sink.options, "-pix_fmt", "yuv420p", "-r", ffmpegExecutorParams.framerate.toString(),
         "-crf", ffmpegExecutorParams.h264ConstantRateFactor.toString(),
         "-g", ffmpegExecutorParams.gopSize.toString(), "-tune", "zerolatency",
         "-f", sink.format, sink.path
@@ -50,7 +50,7 @@ fun getFfmpegCommandMac(ffmpegExecutorParams: FfmpegExecutorParams, sink: Sink):
         "-vsync", "2",
         "-acodec", "aac", "-strict", "-2", "-ar", "44100",
         "-c:v", "libx264", "-preset", ffmpegExecutorParams.videoEncodePreset,
-        sink.options, "-pix_fmt", "yuv420p", "-crf", ffmpegExecutorParams.h264ConstantRateFactor.toString(),
+        *sink.options, "-pix_fmt", "yuv420p", "-crf", ffmpegExecutorParams.h264ConstantRateFactor.toString(),
         "-g", ffmpegExecutorParams.gopSize.toString(), "-tune", "zerolatency",
         "-f", sink.format, sink.path
     )

--- a/src/main/kotlin/org/jitsi/jibri/sink/Sink.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sink/Sink.kt
@@ -38,5 +38,5 @@ interface Sink {
     /**
      * Any ffmpeg command-line options this [Sink] requires
      */
-    val options: String
+    val options: Array<String>
 }

--- a/src/main/kotlin/org/jitsi/jibri/sink/impl/FileSink.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sink/impl/FileSink.kt
@@ -37,5 +37,8 @@ class FileSink(recordingsDirectory: WritableDirectory, callName: String, extensi
     }
     override val path: String = file.path
     override val format: String = file.extension
-    override val options: String = "-profile:v main -level 3.1"
+    override val options: Array<String> = arrayOf(
+        "-profile:v", "main",
+        "-level", "3.1"
+    )
 }

--- a/src/main/kotlin/org/jitsi/jibri/sink/impl/StreamSink.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sink/impl/StreamSink.kt
@@ -25,5 +25,8 @@ import org.jitsi.jibri.sink.Sink
 class StreamSink(val url: String, val streamingMaxBitrate: Int, val streamingBufSize: Int) : Sink {
     override val path: String = url
     override val format: String = "flv"
-    override val options: String = "-maxrate ${streamingMaxBitrate}k -bufsize ${streamingBufSize}k"
+    override val options: Array<String> = arrayOf(
+        "-maxrate", "${streamingMaxBitrate}k",
+        "-bufsize", "${streamingBufSize}k"
+    )
 }

--- a/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
@@ -42,7 +42,7 @@ internal class FfmpegCapturerTest : ShouldSpec() {
 
     init {
         whenever(sink.format).thenReturn("format")
-        whenever(sink.options).thenReturn("options")
+        whenever(sink.options).thenReturn(arrayOf("option1", "option2"))
         whenever(sink.path).thenReturn("path")
 
         "on linux" {
@@ -55,6 +55,8 @@ internal class FfmpegCapturerTest : ShouldSpec() {
                     ffmpegCapturer.start(sink)
                     commandCaptor.firstValue should contain("x11grab")
                     commandCaptor.firstValue should contain("alsa")
+                    commandCaptor.firstValue should contain("option1")
+                    commandCaptor.firstValue should contain("option2")
                 }
             }
             "when launching succeeds" {


### PR DESCRIPTION
when the list of ffmpeg options moved to an array, i forgot to split the
pre-defined options in the sink to match