### PR TITLE
Log more information about the xmpp connection

### DIFF
--- a/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -59,7 +59,7 @@ public class MucClient
     public MucClient(XMPPTCPConnectionConfiguration config)
             throws Exception
     {
-        this(config, "");
+        this(config, config.getXMPPServiceDomain().toString());
     }
 
     /**
@@ -80,54 +80,44 @@ public class MucClient
             @Override
             public void connected(XMPPConnection xmppConnection)
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: connected");
+                logger.info("[" + connectionContext + "] Xmpp connection status: connected");
             }
 
             @Override
             public void authenticated(XMPPConnection xmppConnection, boolean b)
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: authenticated "
-                        + "(resume from previous? " + b + ")");
+                logger.info("[" + connectionContext + "] Xmpp connection status: authenticated "
+                    + "(resume from previous? " + b + ")");
             }
 
             @Override
             public void connectionClosed()
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: closed");
+                logger.info("[" + connectionContext + "] Xmpp connection status: closed");
             }
 
             @Override
             public void connectionClosedOnError(Exception e)
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: closed on error: "
-                        + e);
+                logger.info("[" + connectionContext + "] Xmpp connection status: closed on error: " + e);
             }
 
             @Override
             public void reconnectionSuccessful()
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext
-                        + "]: reconnection successful");
+                logger.info("[" + connectionContext + "] Xmpp connection status: reconnection successful");
             }
 
             @Override
             public void reconnectingIn(int i)
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: reconnecting in " + i);
+                logger.info("[" + connectionContext + "] Xmpp connection status: reconnecting in " + i);
             }
 
             @Override
             public void reconnectionFailed(Exception e)
             {
-                logger.info("Xmpp connection status ["
-                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: reconnection failed: "
-                        + e);
+                logger.info("[" + connectionContext + "] Xmpp connection status: reconnection failed: " + e);
             }
         });
         xmppConnection.connect().login();

--- a/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -56,13 +56,19 @@ public class MucClient
      */
     private List<MultiUserChat> mucs = new ArrayList<>();
 
+    public MucClient(XMPPTCPConnectionConfiguration config)
+            throws Exception
+    {
+        this(config, "");
+    }
+
     /**
      * Connect to the xmpp service defined by the given config
      * @param config xmpp connection details
      * @throws Exception from {@link XMPPTCPConnection#connect()} or
      * {@link XMPPTCPConnection#login()}
      */
-    public MucClient(XMPPTCPConnectionConfiguration config)
+    public MucClient(XMPPTCPConnectionConfiguration config, String connectionContext)
         throws Exception
     {
         PingManager.setDefaultPingInterval(30);
@@ -74,43 +80,54 @@ public class MucClient
             @Override
             public void connected(XMPPConnection xmppConnection)
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: connected");
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: connected");
             }
 
             @Override
             public void authenticated(XMPPConnection xmppConnection, boolean b)
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: authenticated");
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: authenticated "
+                        + "(resume from previous? " + b + ")");
             }
 
             @Override
             public void connectionClosed()
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: closed");
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: closed");
             }
 
             @Override
             public void connectionClosedOnError(Exception e)
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: closed on error");
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: closed on error: "
+                        + e);
             }
 
             @Override
             public void reconnectionSuccessful()
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: reconnection successful");
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext
+                        + "]: reconnection successful");
             }
 
             @Override
             public void reconnectingIn(int i)
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: reconnecting in " + i);
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: reconnecting in " + i);
             }
 
             @Override
             public void reconnectionFailed(Exception e)
             {
-                logger.info("Xmpp connection status [" + xmppConnection.getXMPPServiceDomain() + "]: reconnection failed");
+                logger.info("Xmpp connection status ["
+                        + xmppConnection.getXMPPServiceDomain() + " " + connectionContext + "]: reconnection failed: "
+                        + e);
             }
         });
         xmppConnection.connect().login();

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -96,7 +96,8 @@ class XmppApi(
                     configBuilder.setHostnameVerifier(TrustAllHostnameVerifier())
                 }
                 try {
-                    val mucClient = mucClientProvider(configBuilder.build(), host)
+                    val mucClient =
+                        mucClientProvider(configBuilder.build(), "${config.name}: ${config.controlLogin.domain}@$host")
                     mucClient.addIqRequestHandler(object : JibriSyncIqRequestHandler() {
                         override fun handleJibriIqRequest(jibriIq: JibriIq): IQ {
                             return handleJibriIq(jibriIq, config, mucClient)

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -69,7 +69,7 @@ class XmppApiTest : ShouldSpec() {
         "xmppApi" {
             val xmppApi = XmppApi(jibriManager, listOf(xmppConfig))
             val mucClient: MucClient = mock()
-            val mucClientProvider = { _: XMPPTCPConnectionConfiguration ->
+            val mucClientProvider: MucClientProvider = { _: XMPPTCPConnectionConfiguration, _: String ->
                 mucClient
             }
             val iqHandler = argumentCaptor<AbstractIqRequestHandler>()


### PR DESCRIPTION
The same xmpp domain can be shared across many hosts and the old log message didn't give any indication of which host the status message was for.  For each status update, the log now includes:
1) The 'name' field for the xmpp connection from config.json
2) The xmpp domain
3) The host

e.g.:
```
2018-05-30 11:13:35.000 INFO: [1] class org.jitsi.xmpp.mucclient.MucClient.connected() [brian.jitsi.net: auth.brian.jitsi.net@brian.jitsi.net] Xmpp connection status: connected
```
