### PR TITLE
add some logs around quitting the web call

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -226,9 +226,12 @@ class JibriSelenium(
                 browserOutputLogger.info(it.toString())
             }
         }
+        logger.info("Leaving web call")
         CallPage(chromeDriver).leave()
         currCallUrl = null
+        logger.info("Quitting chrome driver")
         chromeDriver.quit()
+        logger.info("Chrome driver quit")
     }
 
     //TODO: helper func to verify connectivity


### PR DESCRIPTION
we're also a few selenium versions behind, so updating that is another option to figure out the hanging on exit but thought we'd just try this first.