### PR TITLE
Match average bitrate to image size (readable one)

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
@@ -38,7 +38,7 @@ const val FFMPEG_RESTART_ATTEMPTS = 1
 data class FfmpegExecutorParams(
     val resolution: String = "1280x720",
     val framerate: Int = 30,
-    val videoEncodePreset: String = "veryfast",
+    val videoEncodePreset: String = "medium",
     val queueSize: Int = 4096,
     val streamingMaxBitrate: Int = 2976,
     val streamingBufSize: Int = streamingMaxBitrate * 2,
@@ -49,7 +49,7 @@ data class FfmpegExecutorParams(
     // it should look the same or nearly the same as the input but it
     // isn't technically lossless.
     // https://trac.ffmpeg.org/wiki/Encode/H.264#crf
-    val h264ConstantRateFactor: Int = 25,
+    val h264ConstantRateFactor: Int = 17,
     val gopSize: Int = framerate * 2
 )
 


### PR DESCRIPTION
As described here https://community.jitsi.org/t/improve-jibri-recording-resolution/14633
It would be very appreciated to increase the avg bit rate of the recordings to match the image size (12080x720), to be able to read text on the recorded streaming.
Cheers!