### PR TITLE
fix loggers used for process output

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
@@ -62,13 +62,16 @@ class FfmpegExecutor(
     private val processBuilder: ProcessBuilder = ProcessBuilder()
 ) : MonitorableProcess {
     private val logger = Logger.getLogger(this::class.qualifiedName)
-    private val ffmpegOutputLogger = getLoggerWithHandler("ffmpeg", FfmpegFileHandler())
     private val executor = Executors.newSingleThreadExecutor(NameableThreadFactory("FfmpegExecutor"))
     private var processLoggerTask: Future<Boolean>? = null
     /**
      * The currently active (if any) Ffmpeg process
      */
     private var currentFfmpegProc: ProcessWrapper? = null
+
+    companion object {
+        private val ffmpegOutputLogger = getLoggerWithHandler("ffmpeg", FfmpegFileHandler())
+    }
     /**
      * Launch ffmpeg with the given [FfmpegExecutorParams] and using
      * the given [Sink]

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -26,6 +26,7 @@ import org.jitsi.jibri.service.JibriServiceStatus
 import org.jitsi.jibri.util.StatusPublisher
 import org.jitsi.jibri.util.extensions.error
 import org.jitsi.jibri.util.extensions.scheduleAtFixedRate
+import org.jitsi.jibri.util.getLoggerWithHandler
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeDriverService
 import org.openqa.selenium.chrome.ChromeOptions
@@ -100,7 +101,6 @@ class JibriSelenium(
     private val executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 ) : StatusPublisher<JibriServiceStatus>() {
     private val logger = Logger.getLogger(this::class.qualifiedName)
-    private val browserOutputLogger = Logger.getLogger("browser")
     private var chromeDriver: ChromeDriver
     private var currCallUrl: String? = null
 
@@ -109,12 +109,14 @@ class JibriSelenium(
      */
     private var emptyCallTask: ScheduledFuture<*>? = null
 
+    companion object {
+        private val browserOutputLogger = getLoggerWithHandler("browser", BrowserFileHandler())
+    }
+
     /**
      * Set up default chrome driver options (using fake device, etc.)
       */
     init {
-        browserOutputLogger.useParentHandlers = false
-        browserOutputLogger.addHandler(BrowserFileHandler())
         System.setProperty("webdriver.chrome.logfile", "/tmp/chromedriver.log")
         val chromeOptions = ChromeOptions()
         chromeOptions.addArguments(


### PR DESCRIPTION
we were recreating loggers for every service instance, but the handles
don't get cleaned up (even if the logger itself goes out of scope), so
we had effectively multiple loggers all holding a lock on the same file
which stacked up over time and eventually reached the limit and resulted
in an exception:

Error in startService task: java.io.IOException: Couldn’t get lock for
/var/log/jitsi/jibri/ffmpeg.%g.txt, maxLocks: 100 with stack

using a single, static logger makes more sense for these files anyway.