### PR TITLE
Start service error handling

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
@@ -72,7 +72,9 @@ class HttpApi(private val jibriManager: JibriManager) {
     @Produces(MediaType.APPLICATION_JSON)
     fun health(): Response {
         logger.debug("Got health request")
-        return Response.ok(jibriManager.healthCheck()).build()
+        val health = jibriManager.healthCheck()
+        logger.debug("Returning health $health")
+        return Response.ok(health).build()
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
@@ -84,7 +84,7 @@ class FfmpegExecutor(
             return false
         }
         return currentFfmpegProc?.let {
-            logger.info("Starting ffmpeg with command $command")
+            logger.info("Starting ffmpeg with command ${command.joinToString(separator = " ")} ($command)")
             it.start()
             processLoggerTask = logStream(it.getOutput(), ffmpegOutputLogger, executor)
             true


### PR DESCRIPTION
Catch any exceptions in start service when we launch from the xmpp api so we can clean things up correctly and report the error back to the requester (jicofo)