### PR TITLE
Http health

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -146,7 +146,7 @@ fun main(args: Array<String>) {
     xmppApi.start()
 
     // HttpApi
-    launchHttpServer(httpApiPort, HttpApi(jibri))
+    launchHttpServer(httpApiPort, HttpApi(jibri, jibriStatusManager))
 }
 
 fun launchHttpServer(port: Int, component: Any) {

--- a/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
@@ -22,11 +22,13 @@ import org.jitsi.jibri.JibriManager
 import org.jitsi.jibri.RecordingSinkType
 import org.jitsi.jibri.StartServiceResult
 import org.jitsi.jibri.config.XmppCredentials
+import org.jitsi.jibri.health.JibriHealth
 import org.jitsi.jibri.selenium.CallParams
 import org.jitsi.jibri.service.ServiceParams
 import org.jitsi.jibri.service.impl.SipGatewayServiceParams
 import org.jitsi.jibri.service.impl.StreamingParams
 import org.jitsi.jibri.sipgateway.SipClientParams
+import org.jitsi.jibri.status.JibriStatusManager
 import org.jitsi.jibri.util.extensions.debug
 import java.util.logging.Logger
 import javax.ws.rs.Consumes
@@ -60,7 +62,10 @@ data class StartServiceParams(
  * [JibriManager], as well as retrieving the health and status of this Jibri
  */
 @Path("/jibri/api/v1.0")
-class HttpApi(private val jibriManager: JibriManager) {
+class HttpApi(
+    private val jibriManager: JibriManager,
+    private val jibriStatusManager: JibriStatusManager
+) {
     private val logger = Logger.getLogger(this::class.qualifiedName)
 
     /**
@@ -72,7 +77,7 @@ class HttpApi(private val jibriManager: JibriManager) {
     @Produces(MediaType.APPLICATION_JSON)
     fun health(): Response {
         logger.debug("Got health request")
-        val health = jibriManager.healthCheck()
+        val health = JibriHealth(jibriStatusManager.overallStatus, jibriManager.currentEnvironmentContext)
         logger.debug("Returning health $health")
         return Response.ok(health).build()
     }

--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/FfmpegExecutor.kt
@@ -77,18 +77,18 @@ class FfmpegExecutor(
      * the given [Sink]
      */
     fun launchFfmpeg(command: List<String>): Boolean {
-        try {
-            currentFfmpegProc = ProcessWrapper(command, processBuilder = processBuilder)
-        } catch (t: Throwable) {
-            logger.error("Error starting ffmpeg: $t")
-            return false
-        }
-        return currentFfmpegProc?.let {
-            logger.info("Starting ffmpeg with command ${command.joinToString(separator = " ")} ($command)")
-            it.start()
-            processLoggerTask = logStream(it.getOutput(), ffmpegOutputLogger, executor)
+        currentFfmpegProc = ProcessWrapper(command, processBuilder = processBuilder)
+        logger.info("Starting ffmpeg with command ${command.joinToString(separator = " ")} ($command)")
+        return try {
+            currentFfmpegProc?.let {
+                it.start()
+                processLoggerTask = logStream(it.getOutput(), ffmpegOutputLogger, executor)
+            }
             true
-        } ?: run {
+        } catch (t: Throwable) {
+            logger.error("Error starting ffmpeg", t)
+            // We don't need to call stop because we never successfully started
+            currentFfmpegProc = null
             false
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/health/JibriHealth.kt
+++ b/src/main/kotlin/org/jitsi/jibri/health/JibriHealth.kt
@@ -19,9 +19,7 @@ package org.jitsi.jibri.health
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonInclude
-
-//TODO: these classes are used by the http health check API, but that API should be updated to leverage
-// JibriStatusManager
+import org.jitsi.jibri.status.JibriStatus
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 data class EnvironmentContext(
@@ -34,7 +32,7 @@ data class JibriHealth(
     /**
      * Whether or not this Jibri is "busy". See [JibriManager#busy]
      */
-    private val busy: Boolean,
+    private val status: JibriStatus,
     /**
      * Context for the environment Jibri is currently active on
      * (only present if [busy] is true)

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -89,7 +89,6 @@ val RECORDING_URL_OPTIONS = listOf(
     "interfaceConfig.APP_NAME=\"Jibri\""
 )
 
-
 /**
  * The [JibriSelenium] class is responsible for all of the interactions with
  * Selenium.  It:


### PR DESCRIPTION
There are 2 changes here, but one is small:
1) Properly handle an error scenario when launching Ffmpeg
2) Reflect Jibri's overall health in the http api


Please DO NOT SQUASH if merging