### PR TITLE
publish unhealthy on error before stopping

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
+++ b/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
@@ -231,9 +231,9 @@ class JibriManager(
             }
         }
         if (!jibriService.start()) {
-            stopService()
-            statsDClient?.incrementCounter(ASPECT_ERROR, JibriStatsDClient.getTagForService(jibriService))
             publishStatus(ComponentHealthStatus.UNHEALTHY)
+            statsDClient?.incrementCounter(ASPECT_ERROR, JibriStatsDClient.getTagForService(jibriService))
+            stopService()
             return StartServiceResult.ERROR
         }
         return StartServiceResult.SUCCESS


### PR DESCRIPTION
this prevents 'stopService' from publishing idle, therefore going to an
(IDLE, HEALTHY) state before publish the error and go to (IDLE,
UNHEALTHY) state, which caused that awkward double transition.