### PR TITLE
disable chrome logging, overfilling disk

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -127,8 +127,6 @@ class JibriSelenium(
                 "--start-maximized",
                 "--kiosk",
                 "--enabled",
-                "--enable-logging",
-                "--vmodule=*=3",
                 "--disable-infobars",
                 "--alsa-output-device=plug:amix",
                 "--autoplay-policy=no-user-gesture-required"


### PR DESCRIPTION
disables chrome logging until options can be added in config.json to re-enable