### PR TITLE
wait to set presence values until after we have loaded the call page

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
@@ -140,15 +140,15 @@ class FileRecordingJibriService(
 
         whenever(jibriSelenium).transitionsTo(ComponentState.Running) {
             logger.info("Selenium joined the call, starting the capturer")
-            capturer.start(sink)
-        }
-        try {
-            jibriSelenium.addToPresence("session_id", fileRecordingParams.sessionId)
-            jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.FILE.toString())
-            jibriSelenium.sendPresence()
-        } catch (t: Throwable) {
-            logger.error("Error while setting fields in presence", t)
-            publishStatus(ComponentState.Error(ErrorScope.SESSION, "Unable to set presence values"))
+            try {
+                jibriSelenium.addToPresence("session_id", fileRecordingParams.sessionId)
+                jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.FILE.toString())
+                jibriSelenium.sendPresence()
+                capturer.start(sink)
+            } catch (t: Throwable) {
+                logger.error("Error while setting fields in presence", t)
+                publishStatus(ComponentState.Error(ErrorScope.SESSION, "Unable to set presence values"))
+            }
         }
     }
 

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -91,21 +91,20 @@ class StreamingJibriService(
 
         whenever(jibriSelenium).transitionsTo(ComponentState.Running) {
             logger.info("Selenium joined the call, starting capturer")
-            capturer.start(sink)
-        }
-
-        try {
-            jibriSelenium.addToPresence("session_id", streamingParams.sessionId)
-            jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.STREAM.toString())
-            streamingParams.youTubeBroadcastId?.let {
-                if (!jibriSelenium.addToPresence("live-stream-view-url", "http://youtu.be/$it")) {
-                    logger.error("Error adding live stream url to presence")
+            try {
+                jibriSelenium.addToPresence("session_id", streamingParams.sessionId)
+                jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.STREAM.toString())
+                streamingParams.youTubeBroadcastId?.let {
+                    if (!jibriSelenium.addToPresence("live-stream-view-url", "http://youtu.be/$it")) {
+                        logger.error("Error adding live stream url to presence")
+                    }
                 }
+                jibriSelenium.sendPresence()
+                capturer.start(sink)
+            } catch (t: Throwable) {
+                logger.error("Error while setting fields in presence", t)
+                publishStatus(ComponentState.Error(ErrorScope.SESSION, "Unable to set presence values"))
             }
-            jibriSelenium.sendPresence()
-        } catch (t: Throwable) {
-            logger.error("Error while setting fields in presence", t)
-            publishStatus(ComponentState.Error(ErrorScope.SESSION, "Unable to set presence values"))
         }
     }
 


### PR DESCRIPTION
this was a (subtle) regression from the error granularity
changes.  as part of those changes we made JibriSelenium#joinCall async,
so whereas setting these presence values after joinCall returned before
was fine, now we need to wait until JibriSelenium transitions.