### PR TITLE
Fixes stripping room to domain. Fixes #184.

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/util/XmppUtils.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/XmppUtils.kt
@@ -32,7 +32,7 @@ fun getCallUrlInfoFromJid(roomJid: EntityBareJid, stripFromRoomDomain: String, x
     var domain = roomJid.domain.toString()
     // But the room jid domain may have a subdomain that shouldn't be applied to the url, so strip out any
     // string we've been told to remove from the domain
-    domain = domain.replace(stripFromRoomDomain, "", ignoreCase = true)
+    domain = domain.replaceFirst(stripFromRoomDomain, "", ignoreCase = true)
     // Now we need to extract a potential call subdomain, which will be anything that's left in the domain
     //  at this point before the configured xmpp domain.
     val subdomain = domain.subSequence(0, domain.indexOf(xmppDomain, ignoreCase = true)).trim('.')

--- a/src/test/kotlin/org/jitsi/jibri/util/XmppUtilsTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/XmppUtilsTest.kt
@@ -45,6 +45,16 @@ class XmppUtilsTest : ShouldSpec() {
                 val jid = JidCreate.entityBareFrom("${expected.callName}@mucdomain.subdomain.$baseDomain")
                 getCallUrlInfoFromJid(jid, "mucdomain.", baseDomain) shouldBe expected
             }
+            "a basic muc room jid, domain contains part to be stripped" {
+                // domain contains 'conference'
+                val conferenceBaseDomain = "conference.$baseDomain"
+                val expected = CallUrlInfo("https://$conferenceBaseDomain", "roomName")
+                val jid = JidCreate.entityBareFrom("${expected.callName}@conference.$conferenceBaseDomain")
+                should("convert to a call url correctly") {
+                    // we want to strip the first conference from the jid
+                    getCallUrlInfoFromJid(jid, "conference", conferenceBaseDomain) shouldBe expected
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When stripping if the configured domain is 'conference.jitsi.example.com', then
the room will be 'test@conference.conference.jitsi.example.com' and
replace will produce domain 'jitsi.example.com' which is not correct.