### PR TITLE
ffmpeg: change directly reference to an audio interface.

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Commands.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Commands.kt
@@ -29,7 +29,7 @@ fun getFfmpegCommandLinux(ffmpegExecutorParams: FfmpegExecutorParams, sink: Sink
         "-i", ":0.0+0,0",
         "-f", "alsa",
         "-thread_queue_size", ffmpegExecutorParams.queueSize.toString(),
-        "-i", "hw:0,1,0",
+        "-i", "plug:cloop",
         "-acodec", "aac", "-strict", "-2", "-ar", "44100",
         "-c:v", "libx264", "-preset", ffmpegExecutorParams.videoEncodePreset,
         *sink.options, "-pix_fmt", "yuv420p", "-r", ffmpegExecutorParams.framerate.toString(),


### PR DESCRIPTION
Now it just a link to .asound plug, that can be configurable without re-compilation kt files. 
This PR fixes issue described in https://github.com/jitsi/jibri/issues/162#issuecomment-460211648
We don't need change anything else for default behavior, because default interface already described here https://github.com/jitsi/jibri/blob/78258b63aeb24be9abf8bda518dcf328f1e98854/resources/debian-package/etc/jitsi/jibri/asoundrc#L32 We just link ffmpeg into this interface instead hardcoding inside kt file.