### PR TITLE
lower xmpp log level

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -31,3 +31,4 @@ org.jitsi.level = FINE
 
 org.glassfish.level = INFO
 org.osgi.level = INFO
+org.jitsi.xmpp.level = INFO


### PR DESCRIPTION
when the extensions changed to the xmpp-extensions repo, the package
changed and the log level ended up changing, so change this back to
info.