### PR TITLE
take remote participant mute state into account when checking received

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -319,9 +319,11 @@ class JibriSelenium(
         private var numTimesNoMedia = 0
         override fun run(callPage: CallPage): SeleniumEvent? {
             val bitrates = callPage.getBitrates()
-            logger.info("Jibri client receive bitrates: $bitrates")
+            // getNumParticipants includes Jibri, so subtract 1
+            val allClientsMuted = callPage.numRemoteParticipantsMuted() == (callPage.getNumParticipants() - 1)
+            logger.info("Jibri client receive bitrates: $bitrates, all clients muted? $allClientsMuted")
             val downloadBitrate = bitrates.getOrDefault("download", 0L) as Long
-            if (downloadBitrate == 0L) {
+            if (downloadBitrate == 0L && !allClientsMuted) {
                 numTimesNoMedia++
             } else {
                 numTimesNoMedia = 0

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -172,7 +172,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
             is Number -> result.toInt()
             else -> {
                 logger.error("error running numRemoteParticipantsMuted script: $result ${result::class.java}")
-                1
+                0
             }
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -67,7 +67,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         }
     }
 
-    fun getNumParticipants(): Long {
+    fun getNumParticipants(): Int {
         val result = driver.executeScript("""
             try {
                 return APP.conference.membersCount;
@@ -76,7 +76,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
             }
         """.trimMargin())
         return when (result) {
-            is Long -> result
+            is Number -> result.toInt()
             else -> 1
         }
     }
@@ -151,6 +151,29 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
             return result as List<Map<String, Any>>
         } else {
             return listOf()
+        }
+    }
+
+    /**
+     * Returns a count of how many remote participants are totally muted (audio
+     * and video).
+     */
+    fun numRemoteParticipantsMuted(): Int {
+        val result = driver.executeScript("""
+            try {
+                return APP.conference._room.getParticipants()
+                    .filter(participant => participant.isAudioMuted() && participant.isVideoMuted())
+                    .length;
+            } catch (e) {
+                return e.message;
+            }
+        """.trimMargin())
+        return when (result) {
+            is Number -> result.toInt()
+            else -> {
+                logger.error("error running numRemoteParticipantsMuted script: $result ${result::class.java}")
+                1
+            }
         }
     }
 


### PR DESCRIPTION
media

turns out when people often _do_ have a recording running when everyone is audio and video muted (e.g. at the beginning of a call waiting for everyone to join).  this change takes into account the remote participants' mute state before error-ing out based on not receiving any media.