### PR TITLE
remove console logging from defaults

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -1,4 +1,4 @@
-handlers = java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+handlers = java.util.logging.FileHandler
 
 java.util.logging.FileHandler.level = FINE
 java.util.logging.FileHandler.pattern   = /var/log/jitsi/jibri/log.%g.txt
@@ -23,9 +23,6 @@ org.jitsi.jibri.selenium.util.BrowserFileHandler.pattern   = /var/log/jitsi/jibr
 org.jitsi.jibri.selenium.util.BrowserFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
 org.jitsi.jibri.selenium.util.BrowserFileHandler.count = 10
 org.jitsi.jibri.selenium.util.BrowserFileHandler.limit = 10000000
-
-java.util.logging.ConsoleHandler.level = FINE
-java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
 
 org.jitsi.level = FINE
 


### PR DESCRIPTION
updated  jibri logging.properties to remove console logging and console log related options