### PR TITLE
Add support for generic RTMP streaming servers, not just YouTube

### DIFF
--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -43,6 +43,7 @@ None
 	},
 	"sinkType": String, // "stream" for streaming, "file" for recording
 	"youTubeStreamKey": String // If using "stream" above, this is the YouTube stream key to use
+	"rtmpUrl": String // If using "stream" above, this is the full RTMP URL to broadcast to. Overrides youtubeStreamKey if both are present.
 }
 ```
 ##### Success Response

--- a/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
@@ -51,6 +51,7 @@ data class StartServiceParams(
     val callLoginParams: XmppCredentials? = null,
     val sinkType: RecordingSinkType,
     val youTubeStreamKey: String? = null,
+    val rtmpUrl: String? = null,
     /**
      * Params to be used if [RecordingSinkType] is [RecordingSinkType.GATEWAY]
      */
@@ -119,13 +120,14 @@ class HttpApi(
                 }
             }
             RecordingSinkType.STREAM -> {
-                val youTubeStreamKey = startServiceParams.youTubeStreamKey ?: return Response.status(Response.Status.PRECONDITION_FAILED).build()
+                val youTubeStreamKey = startServiceParams.youTubeStreamKey
+                val rtmpUrl = startServiceParams.rtmpUrl
                 // If it's a stream, it must have the callLoginParams set
                 val callLoginParams = startServiceParams.callLoginParams ?: return Response.status(Response.Status.PRECONDITION_FAILED).build()
                 serviceLauncher {
                     jibriManager.startStreaming(
                             ServiceParams(usageTimeoutMinutes = 0),
-                            StreamingParams(startServiceParams.callParams, startServiceParams.sessionId, callLoginParams, youTubeStreamKey),
+                            StreamingParams(startServiceParams.callParams, startServiceParams.sessionId, callLoginParams, youTubeStreamKey, rtmpUrl),
                             environmentContext = null
                     )
                 }

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -293,6 +293,7 @@ class XmppApi(
                         startIq.sessionId,
                         xmppEnvironment.callLogin,
                         youTubeStreamKey = startIq.streamId,
+                        rtmpUrl = startIq.streamUrl,
                         youTubeBroadcastId = startIq.youtubeBroadcastId),
                     EnvironmentContext(xmppEnvironment.name),
                     serviceStatusHandler

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -56,6 +56,10 @@ data class StreamingParams(
      */
     val youTubeStreamKey: String,
     /**
+     * The full RTMP url to use for this stream
+     */
+    val rtmpUrl: String,
+    /**
      * The YouTube broadcast ID for this stream, if we have it
      */
     val youTubeBroadcastId: String? = null
@@ -74,11 +78,19 @@ class StreamingJibriService(
     private val jibriSelenium = JibriSelenium()
 
     init {
-        sink = StreamSink(
-            url = "$YOUTUBE_URL/${streamingParams.youTubeStreamKey}",
-            streamingMaxBitrate = STREAMING_MAX_BITRATE,
-            streamingBufSize = 2 * STREAMING_MAX_BITRATE
-        )
+        if (streamingParams.rtmpUrl) {
+            sink = StreamSink(
+                url = "${streamingParams.rtmpUrl}",
+                streamingMaxBitrate = STREAMING_MAX_BITRATE,
+                streamingBufSize = 2 * STREAMING_MAX_BITRATE
+            )
+        } else {
+            sink = StreamSink(
+                url = "$YOUTUBE_URL/${streamingParams.youTubeStreamKey}",
+                streamingMaxBitrate = STREAMING_MAX_BITRATE,
+                streamingBufSize = 2 * STREAMING_MAX_BITRATE
+            )
+        }
 
         registerSubComponent(JibriSelenium.COMPONENT_ID, jibriSelenium)
         registerSubComponent(FfmpegCapturer.COMPONENT_ID, capturer)


### PR DESCRIPTION
If I understood how everything works correctly, this should enable support for generic RTMP-based broadcasts instead of being locked down to only YouTube (as requested in https://github.com/jitsi/jibri/issues/195 ).
I noticed the system already uses ffmpeg's built-in RTMP support, which is generic and handles much more than just YouTube. All this pull request does is unlock the full RTMP URL as an editable setting, which should be all that's needed to extend support to practically any streaming service/server.

This is my first attempt to write Kotlin, so please do check my work for correctness.
As this is under 40 lines of changes, I hope checking and merging it should be relatively easy. 🤞
