### PR TITLE
Clears child processes when stopping.

### DIFF
--- a/resources/debian-package/etc/systemd/system/jibri.service
+++ b/resources/debian-package/etc/systemd/system/jibri.service
@@ -10,7 +10,6 @@ PermissionsStartOnly=true
 ExecStart=/opt/jitsi/jibri/launch.sh
 ExecStop=/opt/jitsi/jibri/graceful_shutdown.sh
 ExecReload=/opt/jitsi/jibri/graceful_shutdown.sh
-KillMode=process
 Restart=always
 RestartPreventExitStatus=255
 Type=simple


### PR DESCRIPTION
Leaves default value for KillMode, which is 'control-group': all
remaining processes in the control group of this unit will be killed on unit stop.
https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=