### PR TITLE
Support a 'single use' mode in Jibri

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
+++ b/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
@@ -241,7 +241,11 @@ class JibriManager(
         // and reset it
         pendingIdleFunc()
         pendingIdleFunc = {}
-        publishStatus(ComponentBusyStatus.IDLE)
+        if (!config.singleUseMode) {
+            publishStatus(ComponentBusyStatus.IDLE)
+        } else {
+            logger.info("Jibri is in single-use mode, not returning to IDLE")
+        }
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
+++ b/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
@@ -245,6 +245,7 @@ class JibriManager(
             publishStatus(ComponentBusyStatus.IDLE)
         } else {
             logger.info("Jibri is in single-use mode, not returning to IDLE")
+            publishStatus(ComponentBusyStatus.EXPIRED)
         }
     }
 

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -127,8 +127,12 @@ class XmppApi(
      * Function to update outgoing [presence] stanza with jibri status.
      */
     private fun updatePresence(status: JibriStatus) {
-        logger.info("Jibri reports its status is now $status, publishing presence to connections")
-        mucClientManager.setPresenceExtension(status.toJibriStatusExt())
+        if (status.shouldBeSentToMuc()) {
+            logger.info("Jibri reports its status is now $status, publishing presence to connections")
+            mucClientManager.setPresenceExtension(status.toJibriStatusExt())
+        } else {
+            logger.info("Not forwarding status $status to the MUC")
+        }
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -104,7 +104,7 @@ data class JibriConfig(
      * to be restarted in order to be used again.
      */
     @JsonProperty("single_use_mode")
-    val singleUseMode: Boolean = false,
+    val singleUseMode: Boolean = true,
     /**
      * Whether or not pushing stats to statsd
      * should be enabled.  See [org.jitsi.jibri.statsd.JibriStatsDClient].

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -104,7 +104,7 @@ data class JibriConfig(
      * to be restarted in order to be used again.
      */
     @JsonProperty("single_use_mode")
-    val singleUseMode: Boolean = true,
+    val singleUseMode: Boolean = false,
     /**
      * Whether or not pushing stats to statsd
      * should be enabled.  See [org.jitsi.jibri.statsd.JibriStatsDClient].

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -97,6 +97,15 @@ data class JibriConfig(
     @JsonProperty("recording_directory")
     val recordingDirectory: String,
     /**
+     * Whether or not Jibri should return to idle state
+     * after handling (successfully or unsuccessfully)
+     * a request.  A value of 'true' here means that a Jibri
+     * will NOT return back to the IDLE state and will need
+     * to be restarted in order to be used again.
+     */
+    @JsonProperty("single_use_mode")
+    val singleUseMode: Boolean = false,
+    /**
      * Whether or not pushing stats to statsd
      * should be enabled.  See [org.jitsi.jibri.statsd.JibriStatsDClient].
      */

--- a/src/main/kotlin/org/jitsi/jibri/status/ComponentBusyStatus.kt
+++ b/src/main/kotlin/org/jitsi/jibri/status/ComponentBusyStatus.kt
@@ -18,5 +18,10 @@ package org.jitsi.jibri.status
 
 enum class ComponentBusyStatus {
     BUSY,
-    IDLE
+    IDLE,
+    /**
+     * This Jibri has exhausted its 'use' and needs action
+     * (e.g. a restart) before it can be used again
+     */
+    EXPIRED
 }


### PR DESCRIPTION
In this mode, a Jibri denotes its status as `EXPIRED` after a single use (note that a 'use' includes even an unsuccessful session).  This status is reflected in the health check but not the MUC (from Jicofo's view it will go `BUSY` and then not change).