### PR TITLE
Custom empty call timeout

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -158,7 +158,7 @@ class JibriSelenium(
         // for media being received, since the call being empty will also mean Jibri is not receiving media but should
         // not cause Jibri to go unhealthy (like not receiving media when there are others in the call will).
         callStatusChecks = listOf(
-            EmptyCallStatusCheck(),
+            EmptyCallStatusCheck(logger),
             MediaReceivedStatusCheck(logger)
         )
         stateMachine.onStateTransition(this::onSeleniumStateChange)

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -78,7 +78,11 @@ data class JibriSeleniumOptions(
      * Chrome command line flags to add (in addition to the common
      * ones)
      */
-    val extraChromeCommandLineFlags: List<String> = listOf()
+    val extraChromeCommandLineFlags: List<String> = listOf(),
+    /**
+     * How long we should stay in a call with no other participants before quitting
+     */
+    val emptyCallTimeout: Duration = EmptyCallStatusCheck.DEFAULT_CALL_EMPTY_TIMEOUT
 )
 
 val SIP_GW_URL_OPTIONS = listOf(
@@ -158,7 +162,7 @@ class JibriSelenium(
         // for media being received, since the call being empty will also mean Jibri is not receiving media but should
         // not cause Jibri to go unhealthy (like not receiving media when there are others in the call will).
         callStatusChecks = listOf(
-            EmptyCallStatusCheck(logger),
+            EmptyCallStatusCheck(logger, callEmptyTimeout = jibriSeleniumOptions.emptyCallTimeout),
             MediaReceivedStatusCheck(logger)
         )
         stateMachine.onStateTransition(this::onSeleniumStateChange)

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -38,9 +38,7 @@ import org.openqa.selenium.logging.LogType
 import org.openqa.selenium.logging.LoggingPreferences
 import org.openqa.selenium.remote.CapabilityType
 import org.openqa.selenium.remote.UnreachableBrowserException
-import java.time.Clock
 import java.time.Duration
-import java.time.Instant
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -298,7 +296,4 @@ class JibriSelenium(
         chromeDriver.quit()
         logger.info("Chrome driver quit")
     }
-
-
-
 }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheck.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheck.kt
@@ -18,6 +18,9 @@ class EmptyCallStatusCheck(
     private val callEmptyTimeout: Duration = DEFAULT_CALL_EMPTY_TIMEOUT,
     private val clock: Clock = Clock.systemUTC()
 ) : CallStatusCheck {
+    init {
+        logger.info("Starting empty call check with a timeout of $callEmptyTimeout")
+    }
     // The timestamp at which we last saw the call transition from
     // non-empty to empty
     private val callWentEmptyTime = StateTransitionTimeTracker(clock)

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheck.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheck.kt
@@ -2,23 +2,45 @@ package org.jitsi.jibri.selenium.status_checks
 
 import org.jitsi.jibri.selenium.SeleniumEvent
 import org.jitsi.jibri.selenium.pageobjects.CallPage
+import java.time.Clock
+import java.time.Duration
+import java.util.logging.Logger
 
 /**
- * Verify that there are other participants in the call; if there are none
- * then return [SeleniumEvent.CallEmpty].
+ * Verify that there are other participants in the call; if the call is
+ * empty for more than [callEmptyTimeout], then return [SeleniumEvent.CallEmpty].
+ *
+ * NOTE: this class doesn't perform the check automatically, it will only
+ * check for call empty state when [run] is called.
  */
-class EmptyCallStatusCheck : CallStatusCheck {
-    private var numTimesEmpty = 0
+class EmptyCallStatusCheck(
+    private val logger: Logger,
+    private val callEmptyTimeout: Duration = DEFAULT_CALL_EMPTY_TIMEOUT,
+    private val clock: Clock = Clock.systemUTC()
+) : CallStatusCheck {
+    // The timestamp at which we last saw the call transition from
+    // non-empty to empty
+    private val callWentEmptyTime = StateTransitionTimeTracker(clock)
     override fun run(callPage: CallPage): SeleniumEvent? {
-        // >1 since the count will include jibri itself
-        if (callPage.getNumParticipants() > 1) {
-            numTimesEmpty = 0
-        } else {
-            numTimesEmpty++
+        val now = clock.instant()
+        callWentEmptyTime.maybeUpdate(callPage.isCallEmpty())
+
+        return when (callWentEmptyTime.exceededTimeout(callEmptyTimeout)) {
+            true -> {
+                logger.info("Call has been empty since " +
+                    "${callWentEmptyTime.timestampTransitionOccured} " +
+                    "(${Duration.between(callWentEmptyTime.timestampTransitionOccured, now)} ago). " +
+                    "Returning CallEmpty event")
+                SeleniumEvent.CallEmpty
+            }
+            false -> null
         }
-        if (numTimesEmpty >= 2) {
-            return SeleniumEvent.CallEmpty
-        }
-        return null
+    }
+
+    // <= 1 since the count will include jibri itself
+    private fun CallPage.isCallEmpty() = getNumParticipants() <= 1
+
+    companion object {
+        val DEFAULT_CALL_EMPTY_TIMEOUT: Duration = Duration.ofSeconds(30)
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/MediaReceivedStatusCheck.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/MediaReceivedStatusCheck.kt
@@ -4,7 +4,6 @@ import org.jitsi.jibri.selenium.SeleniumEvent
 import org.jitsi.jibri.selenium.pageobjects.CallPage
 import java.time.Clock
 import java.time.Duration
-import java.time.Instant
 import java.util.logging.Logger
 
 /**
@@ -61,30 +60,6 @@ class MediaReceivedStatusCheck(
          * How long we'll stay in the call if all participants are muted
          */
         private val ALL_MUTED_TIMEOUT: Duration = Duration.ofMinutes(10)
-    }
-}
-
-/**
- * Track the most recent timestamp at which we transitioned from
- * an event having not occurred to when it did occur.  Note this
- * tracks the timestamp of that *transition*, not the most recent
- * time the event itself occurred.
- */
-private class StateTransitionTimeTracker(private val clock: Clock) {
-    private var timestampTransitionOccured: Instant? = null
-
-    fun maybeUpdate(eventOccurred: Boolean) {
-        if (eventOccurred && timestampTransitionOccured == null) {
-            timestampTransitionOccured = clock.instant()
-        } else if (!eventOccurred) {
-            timestampTransitionOccured = null
-        }
-    }
-
-    fun exceededTimeout(timeout: Duration): Boolean {
-        return timestampTransitionOccured?.let {
-            Duration.between(it, clock.instant()) > timeout
-        } ?: false
     }
 }
 

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/MediaReceivedStatusCheck.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/MediaReceivedStatusCheck.kt
@@ -62,4 +62,3 @@ class MediaReceivedStatusCheck(
         private val ALL_MUTED_TIMEOUT: Duration = Duration.ofMinutes(10)
     }
 }
-

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/StateTransitionTimeTracker.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/StateTransitionTimeTracker.kt
@@ -27,7 +27,8 @@ import java.time.Instant
  * time the event itself occurred.
  */
 class StateTransitionTimeTracker(private val clock: Clock) {
-    private var timestampTransitionOccured: Instant? = null
+    var timestampTransitionOccured: Instant? = null
+        private set
 
     fun maybeUpdate(eventOccurred: Boolean) {
         if (eventOccurred && timestampTransitionOccured == null) {

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/StateTransitionTimeTracker.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/StateTransitionTimeTracker.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.selenium.status_checks
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Track the most recent timestamp at which we transitioned from
+ * an event having not occurred to when it did occur.  Note this
+ * tracks the timestamp of that *transition*, not the most recent
+ * time the event itself occurred.
+ */
+class StateTransitionTimeTracker(private val clock: Clock) {
+    private var timestampTransitionOccured: Instant? = null
+
+    fun maybeUpdate(eventOccurred: Boolean) {
+        if (eventOccurred && timestampTransitionOccured == null) {
+            timestampTransitionOccured = clock.instant()
+        } else if (!eventOccurred) {
+            timestampTransitionOccured = null
+        }
+    }
+
+    fun exceededTimeout(timeout: Duration): Boolean {
+        return timestampTransitionOccured?.let {
+            Duration.between(it, clock.instant()) > timeout
+        } ?: false
+    }
+}

--- a/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheckTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheckTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.selenium.status_checks
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
+import io.kotlintest.IsolationMode
+import io.kotlintest.minutes
+import io.kotlintest.seconds
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.ShouldSpec
+import org.jitsi.jibri.helpers.FakeClock
+import org.jitsi.jibri.selenium.SeleniumEvent
+import org.jitsi.jibri.selenium.pageobjects.CallPage
+import java.time.Duration
+import java.util.logging.Logger
+
+internal class EmptyCallStatusCheckTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    private val clock: FakeClock = spy()
+    private val callPage: CallPage = mock()
+    private val logger: Logger = mock()
+
+    private val check = EmptyCallStatusCheck(logger, clock = clock)
+
+    init {
+        "when the call was always empty" {
+            whenever(callPage.getNumParticipants()).thenReturn(1)
+            "the check" {
+                should("return empty after the timeout") {
+                    check.run(callPage) shouldBe null
+                    clock.elapse(15.seconds)
+                    check.run(callPage) shouldBe null
+                    clock.elapse(20.seconds)
+                    check.run(callPage) shouldBe SeleniumEvent.CallEmpty
+                }
+            }
+        }
+        "when the call has participants" {
+            whenever(callPage.getNumParticipants()).thenReturn(3)
+            clock.elapse(5.minutes)
+            "the check" {
+                should("never return empty") {
+                    check.run(callPage) shouldBe null
+                    clock.elapse(10.minutes)
+                    check.run(callPage) shouldBe null
+                }
+            }
+            "and then goes empty" {
+                whenever(callPage.getNumParticipants()).thenReturn(1)
+                clock.elapse(20.seconds)
+                "the check" {
+                    should("return empty after the timeout") {
+                        check.run(callPage) shouldBe null
+                        clock.elapse(11.seconds)
+                        check.run(callPage) shouldBe SeleniumEvent.CallEmpty
+                    }
+                }
+                "and then has participants again" {
+                    whenever(callPage.getNumParticipants()).thenReturn(3)
+                    // Some time passed and the check ran once with no participants
+                    clock.elapse(30.seconds)
+                    "the check" {
+                        should("never return empty") {
+                            check.run(callPage) shouldBe null
+                            clock.elapse(10.minutes)
+                            check.run(callPage) shouldBe null
+                        }
+                    }
+                }
+            }
+        }
+        "when a custom timeout is passed" {
+            val customTimeoutCheck = EmptyCallStatusCheck(logger, Duration.ofMinutes(10), clock)
+            "the check" {
+                should("return empty after the timeout") {
+                    customTimeoutCheck.run(callPage) shouldBe null
+                    clock.elapse(15.seconds)
+                    customTimeoutCheck.run(callPage) shouldBe null
+                    clock.elapse(45.seconds)
+                    customTimeoutCheck.run(callPage) shouldBe null
+                    clock.elapse(8.minutes)
+                    customTimeoutCheck.run(callPage) shouldBe null
+                    clock.elapse(61.seconds)
+                    customTimeoutCheck.run(callPage) shouldBe SeleniumEvent.CallEmpty
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheckTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheckTest.kt
@@ -68,7 +68,7 @@ internal class EmptyCallStatusCheckTest : ShouldSpec() {
                 "the check" {
                     should("return empty after the timeout") {
                         check.run(callPage) shouldBe null
-                        clock.elapse(11.seconds)
+                        clock.elapse(31.seconds)
                         check.run(callPage) shouldBe SeleniumEvent.CallEmpty
                     }
                 }


### PR DESCRIPTION
this will allow a custom call-empty-timeout value for Jibri, so for SIP gw cases we can increase it.