### PR TITLE
add an explicit jitsi-util dependency to get the log formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             <artifactId>statemachine</artifactId>
             <version>0.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-util</artifactId>
+            <version>2.13.df50add</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>


### PR DESCRIPTION
we used to get this via jicoco, but jicoco stopped depending on this so
we need to add it here