### PR TITLE
Fix state transition when a bad stream key is entered

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturer.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturer.kt
@@ -103,12 +103,10 @@ class FfmpegCapturer(
                 ffmpegStatusStateMachine.transition(
                     FfmpegEvent.ErrorLine(FfmpegFailedToStart))
             }
-            is ProcessExited -> {
-                logger.info("Ffmpeg quit abruptly.  Last output line: ${ffmpegState.mostRecentOutput}")
-                ffmpegStatusStateMachine.transition(
-                    FfmpegEvent.ErrorLine(FfmpegFailedToStart))
-            }
             else -> {
+                if (ffmpegState.runningState is ProcessExited) {
+                    logger.info("Ffmpeg quit abruptly.  Last output line: ${ffmpegState.mostRecentOutput}")
+                }
                 val status = OutputParser.parse(ffmpegState.mostRecentOutput)
                 ffmpegStatusStateMachine.transition(status.toFfmpegEvent())
             }

--- a/src/test/kotlin/org/jitsi/jibri/sink/impl/FileSinkTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/sink/impl/FileSinkTest.kt
@@ -23,7 +23,6 @@ import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.matchers.string.shouldStartWith
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.ShouldSpec
-import java.nio.file.Path
 import kotlin.random.Random
 
 internal class FileSinkTest : ShouldSpec() {


### PR DESCRIPTION
I'm seeing instances of Jibri failures where a bad stream key is entered end ffmpeg errors really quickly--so quickly that it has exited before we sample the logs at all.  I hadn't seen this before, so we didn't bother parsing the last log line when it exited this quickly and always considered it a system error.  This change parses the last log line as long as ffmpeg didn't fail to start and throws the correct error.