### PR TITLE
fix for ChromeDriver version 80 and later

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -144,6 +144,7 @@ class JibriSelenium(
                 "--disable-infobars",
                 "--autoplay-policy=no-user-gesture-required"
         )
+        chromeOptions.setAcceptInsecureCerts(true)
         chromeOptions.setExperimentalOption("w3c", false)
         chromeOptions.addArguments(jibriSeleniumOptions.extraChromeCommandLineFlags)
         val chromeDriverService = ChromeDriverService.Builder().withEnvironment(


### PR DESCRIPTION
Due to nearest changes in ChromeDriver using url like `https://jitsi.meet/room` is impossible, because the cert is not valid.

#### 79.0.3945.16
* Removed --ignore-certificate-errors from Chrome launch command
#### 80.0.3987.16
* ChromeDriver will add --ignore-certificate-errors flag when acceptInsecureCerts capability is true

The fix adds option `setAcceptInsecureCerts = true` to `chromeOptions`