### PR TITLE
Take ffmpeg process status into account when firing events

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Errors.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Errors.kt
@@ -25,3 +25,4 @@ class FfmpegUnexpectedSignal(outputLine: String) : FfmpegError(ErrorScope.SESSIO
 class BadRtmpUrl(outputLine: String) : FfmpegError(ErrorScope.SESSION, outputLine) {
     override fun shouldRetry(): Boolean = false
 }
+class BrokenPipe(outputLine: String) : FfmpegError(ErrorScope.SESSION, outputLine)

--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Errors.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Errors.kt
@@ -26,3 +26,4 @@ class BadRtmpUrl(outputLine: String) : FfmpegError(ErrorScope.SESSION, outputLin
     override fun shouldRetry(): Boolean = false
 }
 class BrokenPipe(outputLine: String) : FfmpegError(ErrorScope.SESSION, outputLine)
+class QuitUnexpectedly(outputLine: String) : FfmpegError(ErrorScope.SESSION, outputLine)

--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturer.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturer.kt
@@ -27,6 +27,7 @@ import org.jitsi.jibri.util.OsDetector
 import org.jitsi.jibri.util.OsType
 import org.jitsi.jibri.util.ProcessExited
 import org.jitsi.jibri.util.ProcessFailedToStart
+import org.jitsi.jibri.util.ProcessRunning
 import org.jitsi.jibri.util.ProcessState
 import org.jitsi.jibri.util.StatusPublisher
 import org.jitsi.jibri.util.extensions.debug
@@ -108,7 +109,7 @@ class FfmpegCapturer(
                     logger.info("Ffmpeg quit abruptly.  Last output line: ${ffmpegState.mostRecentOutput}")
                 }
                 val status = OutputParser.parse(ffmpegState.mostRecentOutput)
-                ffmpegStatusStateMachine.transition(status.toFfmpegEvent())
+                ffmpegStatusStateMachine.transition(status.toFfmpegEvent(ffmpegState.runningState is ProcessRunning))
             }
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/OutputParser.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/OutputParser.kt
@@ -73,10 +73,6 @@ class OutputParser {
 
         private const val ffmpegEncodingLine = "($ffmpegOutputField)+$zeroOrMoreSpaces"
         private const val ffmpegExitedLine = "Exiting.*signal$zeroOrMoreSpaces($oneOrMoreDigits).*"
-
-        /**
-         * ffmpeg bad rtmp url line
-         */
         private const val badRtmpUrl = "rtmp://.*Input/output error"
         private const val brokenPipe = ".*Broken pipe.*"
 
@@ -98,8 +94,7 @@ class OutputParser {
             // First we'll check if the output represents that ffmpeg has exited
             val exitedMatcher = Pattern.compile(ffmpegExitedLine).matcher(outputLine)
             if (exitedMatcher.matches()) {
-                val signal = exitedMatcher.group(1).toInt()
-                return when (signal) {
+                return when (exitedMatcher.group(1).toInt()) {
                     // 2 is the signal we pass to stop ffmpeg
                     2 -> FfmpegOutputStatus(OutputLineClassification.FINISHED, outputLine)
                     else -> FfmpegUnexpectedSignalStatus(outputLine)

--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/OutputParser.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/OutputParser.kt
@@ -46,6 +46,8 @@ open class FfmpegErrorStatus(val error: JibriError) : FfmpegOutputStatus(OutputL
  */
 class BadRtmpUrlStatus(outputLine: String) : FfmpegErrorStatus(BadRtmpUrl(outputLine))
 
+class BrokenPipeStatus(outputLine: String) : FfmpegErrorStatus(BrokenPipe(outputLine))
+
 /**
  * Ffmpeg quit due to a signal other than what we sent to it
  */
@@ -76,6 +78,7 @@ class OutputParser {
          * ffmpeg bad rtmp url line
          */
         private const val badRtmpUrl = "rtmp://.*Input/output error"
+        private const val brokenPipe = ".*Broken pipe.*"
 
         /**
          * Errors are done a bit differently, as different errors have different scopes.  For example,
@@ -84,7 +87,8 @@ class OutputParser {
          * to a function which takes in the output line and returns an [FfmpegErrorStatus]
          */
         private val errorTypes = mapOf<String, (String) -> FfmpegErrorStatus>(
-            badRtmpUrl to ::BadRtmpUrlStatus
+            badRtmpUrl to ::BadRtmpUrlStatus,
+            brokenPipe to ::BrokenPipeStatus
         )
 
         /**

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -55,7 +55,10 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
                 )
                 when (result) {
                     is Boolean -> result
-                    else -> false
+                    else -> {
+                        logger.debug("Not joined yet: $result")
+                        false
+                    }
                 }
             }
             val totalTime = System.currentTimeMillis() - start

--- a/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/OutputParserTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/OutputParserTest.kt
@@ -69,6 +69,16 @@ internal class OutputParserTest : ShouldSpec() {
                 }
             }
         }
+        "A broken pipe output line" {
+            val outputLine = "av_interleaved_write_frame(): Broken pipe"
+            should("be parsed correctly") {
+                val status = OutputParser.parse(outputLine)
+                status should beInstanceOf<FfmpegErrorStatus>()
+                status as FfmpegErrorStatus
+                status.detail.shouldBe(outputLine)
+                status.error.scope shouldBe ErrorScope.SESSION
+            }
+        }
         "An unexpected exit output line" {
             val outputLine = "Exiting normally, received signal 15."
             should("be parsed correctly") {


### PR DESCRIPTION
This fixes a regression (introduced by me, [here](https://github.com/jitsi/jibri/pull/258/files)] where we don't react to ffmpeg having exited if it didn't exit with an output line we recognize.  It also adds explicit handling for `Broken pipe` errors.

The result of this is that Jibri won't stop the current session, even if ffmpeg has exited, because we don't properly parse that ffmpeg had exited.