### PR TITLE
Don't respond with 'pending' if Jibri is busy

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
+++ b/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
@@ -229,7 +229,9 @@ class JibriManager(
                 }
             }
         }
-        jibriService.start()
+        TaskPools.ioPool.submit {
+            jibriService.start()
+        }
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/JibriIqHelper.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/JibriIqHelper.kt
@@ -30,15 +30,6 @@ import org.jxmpp.jid.Jid
  */
 class JibriIqHelper {
     companion object {
-        fun createResult(jibriIq: JibriIq, status: JibriIq.Status): JibriIq {
-            val result = JibriIq()
-            result.type = IQ.Type.result
-            result.stanzaId = jibriIq.stanzaId
-            result.to = jibriIq.from
-            result.status = status
-            return result
-        }
-
         fun create(from: Jid, type: IQ.Type = IQ.Type.set, status: JibriIq.Status = JibriIq.Status.UNDEFINED): JibriIq {
             val jibriIq = JibriIq()
             jibriIq.to = from
@@ -58,6 +49,7 @@ fun JibriIq.createResult(block: JibriIq.() -> Unit): JibriIq {
     return JibriIq().apply {
         type = IQ.Type.result
         to = this@createResult.from
+        from = this@createResult.to
         stanzaId = this@createResult.stanzaId
         sipAddress = this@createResult.sipAddress
         block()

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/JibriIqHelper.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/JibriIqHelper.kt
@@ -50,6 +50,20 @@ class JibriIqHelper {
     }
 }
 
+/**
+ * Return a result IQ for this [JibriIq], setting a few fields and then
+ * applying [block]
+ */
+fun JibriIq.createResult(block: JibriIq.() -> Unit): JibriIq {
+    return JibriIq().apply {
+        type = IQ.Type.result
+        to = this@createResult.from
+        stanzaId = this@createResult.stanzaId
+        sipAddress = this@createResult.sipAddress
+        block()
+    }
+}
+
 enum class JibriMode(val mode: String) {
     FILE(JibriIq.RecordingMode.FILE.toString()),
     STREAM(JibriIq.RecordingMode.STREAM.toString()),

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -255,7 +255,9 @@ class XmppApi(
     private fun handleStopJibriIq(stopJibriIq: JibriIq): IQ {
         jibriManager.stopService()
         // By this point the service has been fully stopped
-        return JibriIqHelper.createResult(stopJibriIq, JibriIq.Status.OFF)
+        return stopJibriIq.createResult {
+            status = JibriIq.Status.OFF
+        }
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -37,7 +37,6 @@ import org.jitsi.jibri.sipgateway.SipClientParams
 import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.status.JibriStatus
 import org.jitsi.jibri.status.JibriStatusManager
-import org.jitsi.jibri.util.TaskPools
 import org.jitsi.jibri.util.extensions.error
 import org.jitsi.jibri.util.getCallUrlInfoFromJid
 import org.jitsi.xmpp.mucclient.IQListener
@@ -179,44 +178,40 @@ class XmppApi(
         xmppEnvironment: XmppEnvironmentConfig,
         mucClient: MucClient
     ): IQ {
-        logger.info("Received start request")
-        // We don't want to block the response to wait for the service to actually start, so submit a job to
-        // start the service asynchronously and send an IQ with the status after its done.
-        TaskPools.ioPool.submit {
-            val resultIq = JibriIqHelper.create(startJibriIq.from)
-            resultIq.sipAddress = startJibriIq.sipAddress
-            logger.info("Starting service")
-            // If there is an issue with the service while it's running, we need to send an IQ
-            // to notify the caller who invoked the service of its status, so we'll listen
-            // for the service's status while it's running and this method will be invoked
-            // if it changes
-            val serviceStatusHandler = createServiceStatusHandler(startJibriIq, mucClient)
-            try {
-                handleStartService(startJibriIq, xmppEnvironment, serviceStatusHandler)
-            } catch (busy: JibriBusyException) {
-                logger.error("Jibri is currently busy, cannot service this request")
-                resultIq.status = JibriIq.Status.OFF
-                resultIq.failureReason = JibriIq.FailureReason.BUSY
-                resultIq.shouldRetry = true
-                mucClient.sendStanza(resultIq)
-            } catch (iq: UnsupportedIqMode) {
-                logger.error("Unsupported IQ mode: ${iq.iqMode}")
-                resultIq.status = JibriIq.Status.OFF
-                resultIq.failureReason = JibriIq.FailureReason.ERROR
-                resultIq.shouldRetry = false
-                mucClient.sendStanza(resultIq)
-            } catch (t: Throwable) {
-                logger.error("Error starting Jibri service ", t)
-                resultIq.status = JibriIq.Status.OFF
-                resultIq.failureReason = JibriIq.FailureReason.ERROR
-                resultIq.shouldRetry = true
-                mucClient.sendStanza(resultIq)
+        logger.info("Received start request, starting service")
+        // If there is an issue with the service while it's running, we need to send an IQ
+        // to notify the caller who invoked the service of its status, so we'll listen
+        // for the service's status while it's running and this method will be invoked
+        // if it changes
+        val serviceStatusHandler = createServiceStatusHandler(startJibriIq, mucClient)
+        return try {
+            handleStartService(startJibriIq, xmppEnvironment, serviceStatusHandler)
+            logger.info("Sending 'pending' response to start IQ")
+            startJibriIq.createResult {
+                status = JibriIq.Status.PENDING
+            }
+        } catch (busy: JibriBusyException) {
+            logger.error("Jibri is currently busy, cannot service this request")
+            startJibriIq.createResult {
+                status = JibriIq.Status.OFF
+                failureReason = JibriIq.FailureReason.BUSY
+                shouldRetry = true
+            }
+        } catch (iq: UnsupportedIqMode) {
+            logger.error("Unsupported IQ mode: ${iq.iqMode}")
+            startJibriIq.createResult {
+                status = JibriIq.Status.OFF
+                failureReason = JibriIq.FailureReason.ERROR
+                shouldRetry = false
+            }
+        } catch (t: Throwable) {
+            logger.error("Error starting Jibri service ", t)
+            startJibriIq.createResult {
+                status = JibriIq.Status.OFF
+                failureReason = JibriIq.FailureReason.ERROR
+                shouldRetry = true
             }
         }
-        // Immediately respond that the request is pending
-        val initialResponse = JibriIqHelper.createResult(startJibriIq, JibriIq.Status.PENDING)
-        logger.info("Sending 'pending' response to start IQ")
-        return initialResponse
     }
 
     private fun createServiceStatusHandler(request: JibriIq, mucClient: MucClient): JibriServiceStatusHandler {

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -20,7 +20,6 @@ package org.jitsi.jibri.api.xmpp
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify


### PR DESCRIPTION
We ran into the following scenario:

* The same Jicofo sent start requests to the same Jibri for 2 different conferences (right after one another, before the Jibri had a chance to transition to 'BUSY' from the first request).
* Jibri responds to both requests immediately with a `Pending` status.
* Jibri services the first request, and sends an error (`Busy`) for the second request
* Since that error is a new IQ, Jicofo routes it based on the nickname of the Jibri it came from.  It does this by asking each conference which Jibri it is talking with.  Since there are _two_ conferences talking to this Jibri, it routes it to the first one it finds (which may be the wrong one).  This causes a mismatch in between what Jibri is doing and what Jicofo thinks it is doing.

This fix delays the initial `Pending` response by deferring when we launch the new service into a separate thread until after we've determined that the Jibri isn't already busy.