### PR TITLE
allow custom options for chrome driver

### DIFF
--- a/resources/debian-package/etc/jitsi/jibri/config.json
+++ b/resources/debian-package/etc/jitsi/jibri/config.json
@@ -6,6 +6,8 @@
     "recording_directory":"/tmp/recordings",
     // The path to the script which will be run on completed recordings
     "finalize_recording_script_path": "/path/to/finalize_recording.sh",
+    // extra options for chrome driver
+    "chrome_extra_opts": [],
     "xmpp_environments": [
         {
             // A friendly name for this environment which can be used

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -114,5 +114,7 @@ data class JibriConfig(
     @JsonProperty("finalize_recording_script_path")
     val finalizeRecordingScriptPath: String,
     @JsonProperty("xmpp_environments")
-    val xmppEnvironments: List<XmppEnvironmentConfig>
+    val xmppEnvironments: List<XmppEnvironmentConfig>,
+    @JsonProperty("chrome_extra_opts")
+    val chromeExtraOpts: List<String>
 )

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -44,7 +44,11 @@ data class SipGatewayServiceParams(
      * The params needed for bringing a SIP client into
      * the call
      */
-    val sipClientParams: SipClientParams
+    val sipClientParams: SipClientParams,
+    /**
+     * Extra options for Chrome Driver
+     */
+    val chromeExtraOpts: List<String> = listOf()
 )
 
 /**
@@ -58,13 +62,7 @@ class SipGatewayJibriService(
     /**
      * Used for the selenium interaction
      */
-    private val jibriSelenium = JibriSelenium(
-        JibriSeleniumOptions(
-            displayName = sipGatewayServiceParams.sipClientParams.displayName,
-            // by default we wait 30 minutes alone in the call before deciding to hangup
-            emptyCallTimeout = Duration.ofMinutes(30),
-            extraChromeCommandLineFlags = listOf("--alsa-input-device=plughw:1,1"))
-    )
+    private val jibriSelenium: JibriSelenium
     /**
      * The SIP client we'll use to connect to the SIP call (currently only a
      * pjsua implementation exists)
@@ -78,6 +76,14 @@ class SipGatewayJibriService(
     private var processMonitorTask: ScheduledFuture<*>? = null
 
     init {
+        jibriSelenium = JibriSelenium(
+            JibriSeleniumOptions(
+                displayName = sipGatewayServiceParams.sipClientParams.displayName,
+                // by default we wait 30 minutes alone in the call before deciding to hangup
+                emptyCallTimeout = Duration.ofMinutes(30),
+                extraChromeCommandLineFlags = listOf("--alsa-input-device=plughw:1,1") + sipGatewayServiceParams.chromeExtraOpts)
+        )
+
         registerSubComponent(JibriSelenium.COMPONENT_ID, jibriSelenium)
         registerSubComponent(PjsuaClient.COMPONENT_ID, pjsuaClient)
     }

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -22,6 +22,7 @@ import org.jitsi.jibri.capture.ffmpeg.FfmpegCapturer
 import org.jitsi.jibri.config.XmppCredentials
 import org.jitsi.jibri.selenium.CallParams
 import org.jitsi.jibri.selenium.JibriSelenium
+import org.jitsi.jibri.selenium.JibriSeleniumOptions
 import org.jitsi.jibri.selenium.RECORDING_URL_OPTIONS
 import org.jitsi.jibri.service.ErrorSettingPresenceFields
 import org.jitsi.jibri.service.JibriService
@@ -58,7 +59,11 @@ data class StreamingParams(
     /**
      * The YouTube broadcast ID for this stream, if we have it
      */
-    val youTubeBroadcastId: String? = null
+    val youTubeBroadcastId: String? = null,
+    /**
+     * Extra options for Chrome Driver
+     */
+    val chromeExtraOpts: List<String> = listOf()
 )
 
 /**
@@ -71,7 +76,7 @@ class StreamingJibriService(
 ) : StatefulJibriService("Streaming") {
     private val capturer = FfmpegCapturer()
     private val sink: Sink
-    private val jibriSelenium = JibriSelenium()
+    private val jibriSelenium: JibriSelenium
 
     init {
         sink = StreamSink(
@@ -79,6 +84,9 @@ class StreamingJibriService(
             streamingMaxBitrate = STREAMING_MAX_BITRATE,
             streamingBufSize = 2 * STREAMING_MAX_BITRATE
         )
+
+        jibriSelenium = JibriSelenium(JibriSeleniumOptions().copy(
+            extraChromeCommandLineFlags = streamingParams.chromeExtraOpts))
 
         registerSubComponent(JibriSelenium.COMPONENT_ID, jibriSelenium)
         registerSubComponent(FfmpegCapturer.COMPONENT_ID, capturer)


### PR DESCRIPTION
This change will allow to customize chrome arguments from outside jibri code. This is done with an extra environment variable 
`CHROME_DRIVER_EXTRA_OPTS`.

closes #298 