### PR TITLE
Change pid helper

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/util/ProcessWrapper.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/ProcessWrapper.kt
@@ -17,7 +17,7 @@
 package org.jitsi.jibri.util
 
 import org.jitsi.jibri.util.extensions.error
-import org.jitsi.jibri.util.extensions.pid
+import org.jitsi.jibri.util.extensions.pidValue
 import java.io.InputStream
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -98,7 +98,7 @@ class ProcessWrapper(
         // because we want them to read everything available from the
         // process' inputstream. Once it's done, they'll read
         // the EOF and close things up correctly
-        runtime.exec("kill -s SIGINT ${process.pid}")
+        runtime.exec("kill -s SIGINT ${process.pidValue}")
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/util/extensions/Process.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/extensions/Process.kt
@@ -21,7 +21,7 @@ import java.lang.reflect.Field
 /**
  * Mimic the "pid" member of Java 9's [Process].
  */
-val Process.pid: Long
+val Process.pidValue: Long
     get() {
         var pid: Long = -1
         try {

--- a/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
@@ -24,7 +24,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
-import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.contain
 import io.kotest.matchers.collections.shouldNotBeEmpty

--- a/src/test/kotlin/org/jitsi/jibri/selenium/SeleniumStateMachineTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/SeleniumStateMachineTest.kt
@@ -18,7 +18,6 @@ package org.jitsi.jibri.selenium
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
-import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.beInstanceOf
 import io.kotest.matchers.collections.haveSize

--- a/src/test/kotlin/org/jitsi/jibri/util/JibriSubprocessTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/JibriSubprocessTest.kt
@@ -22,7 +22,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.kotest.core.spec.IsolationMode
-import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty


### PR DESCRIPTION
This was purposefully named after the Java 9 `Process#pid` field in hopes of easing the transition, but in practice it just created conflicts which caused issues.  I've not specifically tested Jibri with Java 9+ yet (other than verifying compilation with Java 11), but this is a precursor to doing further testing.