### PR TITLE
Update unit tests, remove need to use new jvm for each test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <junit.version>5.2.0</junit.version>
         <jetty.version>9.4.15.v20190215</jetty.version>
         <kotest.version>4.1.1</kotest.version>
+        <mockk.version>1.10.0</mockk.version>
     </properties>
 
     <dependencies>
@@ -182,6 +183,12 @@
             <groupId>io.kotest</groupId>
             <artifactId>kotest-runner-console-jvm</artifactId>
             <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
+            <version>1.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -191,12 +191,6 @@
             <version>1.10.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
-            <version>2.1.0</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->
         <dependency>
             <groupId>net.bytebuddy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
-            <version>1.10.0</version>
+            <version>${mockk.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->

--- a/pom.xml
+++ b/pom.xml
@@ -274,12 +274,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
-                <configuration>
-                    <!-- Since we now have some things that are accessed globally but overwritten by tests
-                     (task pools, for example), we don't want the tests interfering with one another as they
-                     mock things out, so make sure we run each in isolation -->
-                    <reuseForks>false</reuseForks>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
@@ -205,7 +205,7 @@ class FileRecordingJibriService(
             )
             with(processFactory.createProcess(finalizeCommand)) {
                 start()
-                val streamDone = LoggingUtils.logOutput(this, logger)
+                val streamDone = LoggingUtils.logOutputOfProcess(this, logger)
                 waitFor()
                 // Make sure we get all the logs
                 try {

--- a/src/main/kotlin/org/jitsi/jibri/util/JibriSubprocess.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/JibriSubprocess.kt
@@ -44,7 +44,7 @@ class JibriSubprocess(
                 processStatePublisher = processStatePublisherProvider(it)
                 processStatePublisher!!.addStatusHandler(this::publishStatus)
                 if (processOutputLogger != null) {
-                    processLoggerTask = LoggingUtils.logOutput(it, processOutputLogger)
+                    processLoggerTask = LoggingUtils.logOutputOfProcess(it, processOutputLogger)
                 }
             } ?: run {
                 throw Exception("Process was null")

--- a/src/main/kotlin/org/jitsi/jibri/util/LoggingUtils.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/LoggingUtils.kt
@@ -27,12 +27,11 @@ import java.util.logging.Logger
 class LoggingUtils {
     companion object {
         var createPublishingTail: (InputStream, (String) -> Unit) -> PublishingTail = ::PublishingTail
+
         /**
-         * A helper function to log a given [ProcessWrapper]'s output to the given [Logger].
-         * A future is returned which will be completed when the end of the given
-         * stream is reached.
+         * The default implementation of the process output logger
          */
-        var logOutput: (ProcessWrapper, Logger) -> Future<Boolean> = { process, logger ->
+        val OutputLogger: (ProcessWrapper, Logger) -> Future<Boolean> = { process, logger ->
             TaskPools.ioPool.submit(Callable<Boolean> {
                 val reader = BufferedReader(InputStreamReader(process.getOutput()))
 
@@ -43,6 +42,21 @@ class LoggingUtils {
 
                 return@Callable true
             })
+        }
+
+        /**
+         * A variable pointing to the current impl of the process output logger function.
+         * Overridable so tests can change it.
+         */
+        var logOutput = OutputLogger
+
+        /**
+         * A helper function to log a given [ProcessWrapper]'s output to the given [Logger].
+         * A future is returned which will be completed when the end of the given
+         * stream is reached.
+         */
+        fun logOutputOfProcess(process: ProcessWrapper, logger: Logger): Future<Boolean> {
+            return logOutput(process, logger)
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/util/TaskPools.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/TaskPools.kt
@@ -28,9 +28,12 @@ import java.util.concurrent.ScheduledExecutorService
  */
 class TaskPools {
     companion object {
-        var ioPool: ExecutorService =
-                Executors.newCachedThreadPool(NameableThreadFactory("IO Pool"))
-        var recurringTasksPool: ScheduledExecutorService =
-                Executors.newSingleThreadScheduledExecutor(NameableThreadFactory("Recurring Tasks Pool"))
+        val DefaultIoPool: ExecutorService =
+            Executors.newCachedThreadPool(NameableThreadFactory("IO Pool"))
+        val DefaultRecurringTaskPool: ScheduledExecutorService =
+            Executors.newSingleThreadScheduledExecutor(NameableThreadFactory("Recurring Tasks Pool"))
+
+        var ioPool: ExecutorService = DefaultIoPool
+        var recurringTasksPool: ScheduledExecutorService = DefaultRecurringTaskPool
     }
 }

--- a/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
@@ -17,24 +17,23 @@
 
 package org.jitsi.jibri.api.http.internal
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.reset
-import com.nhaarman.mockitokotlin2.whenever
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
 import org.jitsi.jibri.util.TaskPools
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 
 class InternalHttpApiTest : ShouldSpec() {
-    private val executor: ScheduledExecutorService = mock()
-    private val future: ScheduledFuture<*> = mock()
+    private val executor: ScheduledExecutorService = mockk()
+    private val future: ScheduledFuture<*> = mockk()
 
     init {
         beforeTest {
-            reset(executor, future)
-            whenever(executor.schedule(any(), any(), any())).thenReturn(future)
+            clearMocks(executor, future)
+            every { executor.schedule(any(), any(), any()) } returns future
             TaskPools.recurringTasksPool = executor
         }
 

--- a/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
@@ -22,6 +22,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import org.jitsi.jibri.helpers.resetScheduledPool
+import org.jitsi.jibri.helpers.setScheduledPool
 import org.jitsi.jibri.util.TaskPools
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
@@ -31,10 +33,17 @@ class InternalHttpApiTest : ShouldSpec() {
     private val future: ScheduledFuture<*> = mockk()
 
     init {
+        beforeSpec {
+            TaskPools.setScheduledPool(executor)
+        }
+
         beforeTest {
             clearMocks(executor, future)
             every { executor.schedule(any(), any(), any()) } returns future
-            TaskPools.recurringTasksPool = executor
+        }
+
+        afterSpec {
+            TaskPools.resetScheduledPool()
         }
 
         context("gracefulShutdown") {

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -18,18 +18,19 @@
 package org.jitsi.jibri.api.xmpp
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.beInstanceOf
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import org.jitsi.jibri.JibriBusyException
 import org.jitsi.xmpp.extensions.jibri.JibriIq
 import org.jitsi.jibri.JibriManager
@@ -73,7 +74,7 @@ class XmppApiTest : ShouldSpec() {
     }
 
     init {
-        val jibriManager: JibriManager = mock()
+        val jibriManager: JibriManager = mockk(relaxed = true)
         val xmppConfig = XmppEnvironmentConfig(
             name = "xmppEnvName",
             xmppServerHosts = listOf("xmppServerHost1", "xmppServerHost2"),
@@ -102,16 +103,16 @@ class XmppApiTest : ShouldSpec() {
             usageTimeoutMins = 0,
             trustAllXmppCerts = true
         )
-        val jibriStatusManager: JibriStatusManager = mock()
+        val jibriStatusManager: JibriStatusManager = mockk(relaxed = true)
         // the initial status is idle
         val expectedStatus =
                 JibriStatus(ComponentBusyStatus.IDLE, OverallHealth(ComponentHealthStatus.HEALTHY, mapOf()))
-        whenever(jibriStatusManager.overallStatus).thenReturn(expectedStatus)
+        every { jibriStatusManager.overallStatus } returns expectedStatus
 
         beforeTest {
-            val executorService: ExecutorService = mock()
-            whenever(executorService.submit(any<Runnable>())).then {
-                (it.arguments.first() as Runnable).run()
+            val executorService: ExecutorService = mockk()
+            every { executorService.submit(any<Runnable>()) } answers {
+                firstArg<Runnable>().run()
                 CompletableFuture<Unit>()
             }
             TaskPools.ioPool = executorService
@@ -119,23 +120,23 @@ class XmppApiTest : ShouldSpec() {
 
         context("xmppApi") {
             val xmppApi = XmppApi(jibriManager, listOf(xmppConfig), jibriStatusManager)
-            val mucClientManager: MucClientManager = mock()
+            val mucClientManager: MucClientManager = mockk(relaxed = true)
             // A dummy MucClient we'll use to be the one incoming messages are received on
-            val mucClient: MucClient = mock()
-            whenever(mucClient.id).thenReturn(xmppConfig.xmppServerHosts.first())
+            val mucClient: MucClient = mockk(relaxed = true)
+            every { mucClient.id } returns xmppConfig.xmppServerHosts.first()
             xmppApi.start(mucClientManager)
             should("add itself as the IQ listener for the MUC client manager") {
-                verify(mucClientManager).setIQListener(xmppApi)
+                verify { mucClientManager.setIQListener(xmppApi) }
             }
             should("create a muc client for each xmpp host") {
-                verify(mucClientManager, times(2)).addMucClient(any())
+                verify(exactly = 2) { mucClientManager.addMucClient(any()) }
             }
 
             context("when receiving a start recording iq") {
                 val jibriIq = createJibriIq(JibriIq.Action.START, JibriIq.RecordingMode.FILE)
                 context("and jibri is idle") {
-                    val statusHandler = argumentCaptor<JibriServiceStatusHandler>()
-                    whenever(jibriManager.startFileRecording(any(), any(), any(), statusHandler.capture())).thenAnswer { }
+                    val statusHandler = slot<JibriServiceStatusHandler>()
+                    every { jibriManager.startFileRecording(any(), any(), any(), capture(statusHandler)) } just Runs
                     val response = xmppApi.handleIq(jibriIq, mucClient)
                     should("send a pending response to the original IQ request") {
                         response shouldNotBe null
@@ -144,38 +145,38 @@ class XmppApiTest : ShouldSpec() {
                         response.status shouldBe JibriIq.Status.PENDING
                     }
                     context("after the service starts up") {
-                        statusHandler.firstValue(ComponentState.Running)
+                        statusHandler.captured(ComponentState.Running)
                         should("send a success response") {
-                            val sentStanzas = argumentCaptor<Stanza>()
-                            verify(mucClient).sendStanza(sentStanzas.capture())
-                            sentStanzas.allValues.size shouldBe 1
-                            (sentStanzas.firstValue as JibriIq).status shouldBe JibriIq.Status.ON
+                            val sentStanzas = mutableListOf<Stanza>()
+                            verify { mucClient.sendStanza(capture(sentStanzas)) }
+                            sentStanzas.size shouldBe 1
+                            sentStanzas.first().shouldBeInstanceOf<JibriIq> {
+                                it.status shouldBe JibriIq.Status.ON
+                            }
                         }
                         context("and it is stopped") {
 //                            whenever(jibriManager.stopService()) doAnswer {}
                             val stopIq = createJibriIq(JibriIq.Action.STOP)
                             val stopResponse = xmppApi.handleIq(stopIq, mucClient)
                             should("respond correctly") {
-                                verify(jibriManager).stopService()
+                                verify { jibriManager.stopService() }
                                 stopResponse shouldBeResponseTo stopIq
-                                stopResponse should beInstanceOf<JibriIq>()
-                                stopResponse as JibriIq
-                                stopResponse.status shouldBe JibriIq.Status.OFF
+                                stopResponse.shouldBeInstanceOf<JibriIq> {
+                                    it.status shouldBe JibriIq.Status.OFF
+                                }
                             }
                         }
                     }
                 }
                 context("and jibri is busy") {
-                    whenever(jibriManager.startFileRecording(any(), any(), any(), any())).thenAnswer {
-                        throw JibriBusyException()
-                    }
+                    every { jibriManager.startFileRecording(any(), any(), any(), any()) } throws JibriBusyException()
                     should("send an error IQ") {
                         val response = xmppApi.handleIq(jibriIq, mucClient)
-                        response should beInstanceOf<JibriIq>()
-                        response as JibriIq
-                        response.status shouldBe JibriIq.Status.OFF
-                        response.failureReason shouldBe JibriIq.FailureReason.BUSY
-                        response.shouldRetry shouldBe true
+                        response.shouldBeInstanceOf<JibriIq> {
+                            it.status shouldBe JibriIq.Status.OFF
+                            it.failureReason shouldBe JibriIq.FailureReason.BUSY
+                            it.shouldRetry shouldBe true
+                        }
                     }
                 }
                 context("with application data") {
@@ -191,17 +192,17 @@ class XmppApiTest : ShouldSpec() {
                     val jsonString = jacksonObjectMapper().writeValueAsString(appData)
                     jibriIq.appData = jsonString
 
-                    val serviceParams = argumentCaptor<ServiceParams>()
-                    whenever(jibriManager.startFileRecording(serviceParams.capture(), any(), any(), any())).thenAnswer { }
+                    val serviceParams = mutableListOf<ServiceParams>()
+                    every { jibriManager.startFileRecording(capture(serviceParams), any(), any(), any()) } just Runs
                     xmppApi.handleIq(jibriIq, mucClient)
                     should("parse and pass the app data") {
-                        serviceParams.allValues.size shouldBe 1
-                        serviceParams.firstValue.appData shouldBe appData
+                        serviceParams.size shouldBe 1
+                        serviceParams.first().appData shouldBe appData
                     }
                 }
                 context("from a muc client it doesn't recognize") {
-                    val unknownMucClient: MucClient = mock()
-                    whenever(unknownMucClient.id).thenReturn("unknown name")
+                    val unknownMucClient: MucClient = mockk()
+                    every { unknownMucClient.id } returns "unknown name"
                     val result = xmppApi.handleIq(jibriIq, unknownMucClient)
                     result.error shouldNotBe null
                     result.error.condition shouldBe XMPPError.Condition.bad_request

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -37,6 +37,8 @@ import org.jitsi.jibri.JibriManager
 import org.jitsi.jibri.config.XmppCredentials
 import org.jitsi.jibri.config.XmppEnvironmentConfig
 import org.jitsi.jibri.config.XmppMuc
+import org.jitsi.jibri.helpers.resetIoPool
+import org.jitsi.jibri.helpers.setIoPool
 import org.jitsi.jibri.service.AppData
 import org.jitsi.jibri.service.JibriServiceStatusHandler
 import org.jitsi.jibri.service.ServiceParams
@@ -109,13 +111,17 @@ class XmppApiTest : ShouldSpec() {
                 JibriStatus(ComponentBusyStatus.IDLE, OverallHealth(ComponentHealthStatus.HEALTHY, mapOf()))
         every { jibriStatusManager.overallStatus } returns expectedStatus
 
-        beforeTest {
+        beforeSpec {
             val executorService: ExecutorService = mockk()
             every { executorService.submit(any<Runnable>()) } answers {
                 firstArg<Runnable>().run()
                 CompletableFuture<Unit>()
             }
-            TaskPools.ioPool = executorService
+            TaskPools.setIoPool(executorService)
+        }
+
+        afterSpec {
+            TaskPools.resetIoPool()
         }
 
         context("xmppApi") {

--- a/src/test/kotlin/org/jitsi/jibri/helpers/Helpers.kt
+++ b/src/test/kotlin/org/jitsi/jibri/helpers/Helpers.kt
@@ -18,8 +18,11 @@ package org.jitsi.jibri.helpers
 
 import org.jitsi.jibri.util.LoggingUtils
 import org.jitsi.jibri.util.ProcessWrapper
+import org.jitsi.jibri.util.TaskPools
 import java.time.Duration
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
 import java.util.logging.Logger
 
 /**
@@ -78,4 +81,20 @@ fun LoggingUtils.Companion.setTestOutputLogger(outputLogger: (ProcessWrapper, Lo
 
 fun LoggingUtils.Companion.resetOutputLogger() {
     logOutput = OutputLogger
+}
+
+fun TaskPools.Companion.setIoPool(pool: ExecutorService) {
+    ioPool = pool
+}
+
+fun TaskPools.Companion.resetIoPool() {
+    ioPool = DefaultIoPool
+}
+
+fun TaskPools.Companion.setScheduledPool(pool: ScheduledExecutorService) {
+    recurringTasksPool = pool
+}
+
+fun TaskPools.Companion.resetScheduledPool() {
+    recurringTasksPool = DefaultRecurringTaskPool
 }

--- a/src/test/kotlin/org/jitsi/jibri/helpers/Helpers.kt
+++ b/src/test/kotlin/org/jitsi/jibri/helpers/Helpers.kt
@@ -16,7 +16,11 @@
  */
 package org.jitsi.jibri.helpers
 
+import org.jitsi.jibri.util.LoggingUtils
+import org.jitsi.jibri.util.ProcessWrapper
 import java.time.Duration
+import java.util.concurrent.Future
+import java.util.logging.Logger
 
 /**
  * Custom version of kotlin.test's [io.kotlintest.eventually] which uses milliseconds
@@ -66,4 +70,12 @@ fun <T> forAllOf(duration: Duration, func: () -> T) {
         times++
         Thread.sleep(500)
     }
+}
+
+fun LoggingUtils.Companion.setTestOutputLogger(outputLogger: (ProcessWrapper, Logger) -> Future<Boolean>) {
+    logOutput = outputLogger
+}
+
+fun LoggingUtils.Companion.resetOutputLogger() {
+    logOutput = OutputLogger
 }

--- a/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheckTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/EmptyCallStatusCheckTest.kt
@@ -16,12 +16,12 @@
 
 package org.jitsi.jibri.selenium.status_checks
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.whenever
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
 import org.jitsi.jibri.helpers.FakeClock
 import org.jitsi.jibri.helpers.minutes
 import org.jitsi.jibri.helpers.seconds
@@ -33,15 +33,15 @@ import java.util.logging.Logger
 internal class EmptyCallStatusCheckTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val clock: FakeClock = spy()
-    private val callPage: CallPage = mock()
-    private val logger: Logger = mock()
+    private val clock: FakeClock = spyk()
+    private val callPage: CallPage = mockk()
+    private val logger: Logger = mockk(relaxed = true)
 
     private val check = EmptyCallStatusCheck(logger, clock = clock)
 
     init {
         context("when the call was always empty") {
-            whenever(callPage.getNumParticipants()).thenReturn(1)
+            every { callPage.getNumParticipants() } returns 1
             context("the check") {
                 should("return empty after the timeout") {
                     check.run(callPage) shouldBe null
@@ -53,7 +53,7 @@ internal class EmptyCallStatusCheckTest : ShouldSpec() {
             }
         }
         context("when the call has participants") {
-            whenever(callPage.getNumParticipants()).thenReturn(3)
+            every { callPage.getNumParticipants() } returns 3
             clock.elapse(5.minutes)
             context("the check") {
                 should("never return empty") {
@@ -63,7 +63,7 @@ internal class EmptyCallStatusCheckTest : ShouldSpec() {
                 }
             }
             context("and then goes empty") {
-                whenever(callPage.getNumParticipants()).thenReturn(1)
+                every { callPage.getNumParticipants() } returns 1
                 clock.elapse(20.seconds)
                 context("the check") {
                     should("return empty after the timeout") {
@@ -73,7 +73,7 @@ internal class EmptyCallStatusCheckTest : ShouldSpec() {
                     }
                 }
                 context("and then has participants again") {
-                    whenever(callPage.getNumParticipants()).thenReturn(3)
+                    every { callPage.getNumParticipants() } returns 3
                     // Some time passed and the check ran once with no participants
                     clock.elapse(30.seconds)
                     context("the check") {
@@ -87,6 +87,7 @@ internal class EmptyCallStatusCheckTest : ShouldSpec() {
             }
         }
         context("when a custom timeout is passed") {
+            every { callPage.getNumParticipants() } returns 1
             val customTimeoutCheck = EmptyCallStatusCheck(logger, Duration.ofMinutes(10), clock)
             context("the check") {
                 should("return empty after the timeout") {

--- a/src/test/kotlin/org/jitsi/jibri/util/LoggingUtilsKtTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/LoggingUtilsKtTest.kt
@@ -48,7 +48,7 @@ internal class LoggingUtilsKtTest : FunSpec() {
         }
 
         test("logStream should write log lines to the given logger") {
-            LoggingUtils.logOutput(process, logger)
+            LoggingUtils.logOutputOfProcess(process, logger)
             thread {
                 for (i in 0..4) {
                     pipedOutputStream.write("$i\n".toByteArray())
@@ -65,7 +65,7 @@ internal class LoggingUtilsKtTest : FunSpec() {
         }
 
         test("logStream should complete the task when EOF is reached") {
-            val streamClosed = LoggingUtils.logOutput(process, logger)
+            val streamClosed = LoggingUtils.logOutputOfProcess(process, logger)
             thread {
                 for (i in 0..4) {
                     pipedOutputStream.write("$i\n".toByteArray())

--- a/src/test/kotlin/org/jitsi/jibri/util/LoggingUtilsKtTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/LoggingUtilsKtTest.kt
@@ -17,15 +17,13 @@
 
 package org.jitsi.jibri.util
 
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.reset
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.jitsi.jibri.helpers.seconds
 import org.jitsi.jibri.helpers.within
 import java.io.PipedInputStream
@@ -36,17 +34,17 @@ import kotlin.concurrent.thread
 internal class LoggingUtilsKtTest : FunSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val process: ProcessWrapper = mock()
+    private val process: ProcessWrapper = mockk()
     private lateinit var pipedOutputStream: PipedOutputStream
     private lateinit var inputStream: PipedInputStream
-    private val logger: Logger = mock()
+    private val logger: Logger = mockk(relaxed = true)
 
     init {
         beforeTest {
             pipedOutputStream = PipedOutputStream()
             inputStream = PipedInputStream(pipedOutputStream)
-            reset(logger)
-            whenever(process.getOutput()).thenReturn(inputStream)
+            clearMocks(logger)
+            every { process.getOutput() } returns inputStream
         }
 
         test("logStream should write log lines to the given logger") {
@@ -57,11 +55,11 @@ internal class LoggingUtilsKtTest : FunSpec() {
                 }
             }
 
-            val logLine = argumentCaptor<String>()
+            val logLines = mutableListOf<String>()
             within(5.seconds) {
-                verify(logger, times(5)).info(logLine.capture())
+                verify(exactly = 5) { logger.info(capture(logLines)) }
             }
-            logLine.allValues.forEachIndexed { index, value ->
+            logLines.forEachIndexed { index, value ->
                 index.toString() shouldBe value
             }
         }
@@ -74,11 +72,11 @@ internal class LoggingUtilsKtTest : FunSpec() {
                 }
                 pipedOutputStream.close()
             }
-            val logLine = argumentCaptor<String>()
+            val logLines = mutableListOf<String>()
             within(5.seconds) {
-                verify(logger, times(5)).info(logLine.capture())
+                verify(exactly = 5) { logger.info(capture(logLines)) }
             }
-            logLine.allValues.forEachIndexed { index, value ->
+            logLines.forEachIndexed { index, value ->
                 index.toString() shouldBe value
             }
             within(5.seconds) {


### PR DESCRIPTION
This replaces use of mockito-kotlin, which is a set of wrapper around a java mocking lib, to mockk, a native kotlin mocking lib.  It also cleans up code that stubs out globals and no longer requires using a new jvm for each test (which reduces the time to run the tests by more than 50% on my machine)