### PR TITLE
Add a Jibri status 'webhook'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <jetty.version>9.4.15.v20190215</jetty.version>
         <kotest.version>4.1.1</kotest.version>
         <mockk.version>1.10.0</mockk.version>
+        <ktor.version>1.3.1</ktor.version>
     </properties>
 
     <dependencies>
@@ -164,6 +165,16 @@
             <groupId>org.jitsi</groupId>
             <artifactId>jitsi-util</artifactId>
             <version>2.13.df50add</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-apache</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-jackson</artifactId>
+            <version>${ktor.version}</version>
         </dependency>
 
         <!-- testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,11 @@
             <version>${mockk.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-mock-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->
         <dependency>
             <groupId>net.bytebuddy</groupId>

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -125,6 +125,7 @@ fun main(args: Array<String>) {
     jibriStatusManager.addStatusHandler {
         webhookClient.updateStatus(it)
     }
+    jibriConfig.webhookSubscribers.forEach { webhookClient.addSubscriber(it) }
     val statusUpdaterTask = TaskPools.recurringTasksPool.scheduleAtFixedRate(
         30,
         TimeUnit.SECONDS
@@ -139,7 +140,7 @@ fun main(args: Array<String>) {
         } catch (t: Throwable) {
             logger.error("Error cleaning up status updater task")
         }
-        exitProcess(0)
+        exitProcess(exitCode)
     }
 
     val configChangedHandler = {

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -40,8 +40,12 @@ import org.jitsi.jibri.statsd.JibriStatsDClient
 import org.jitsi.jibri.status.ComponentBusyStatus
 import org.jitsi.jibri.status.ComponentHealthStatus
 import org.jitsi.jibri.status.JibriStatusManager
+import org.jitsi.jibri.util.TaskPools
 import org.jitsi.jibri.util.extensions.error
+import org.jitsi.jibri.util.extensions.scheduleAtFixedRate
+import org.jitsi.jibri.webhooks.v1.WebhookClient
 import java.io.File
+import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import javax.ws.rs.ext.ContextResolver
 import kotlin.system.exitProcess
@@ -116,13 +120,34 @@ fun main(args: Array<String>) {
         }
     }
 
-    // InternalHttpApi
+    val webhookClient = WebhookClient(jibriConfig.jibriId)
+
+    jibriStatusManager.addStatusHandler {
+        webhookClient.updateStatus(it)
+    }
+    val statusUpdaterTask = TaskPools.recurringTasksPool.scheduleAtFixedRate(
+        30,
+        TimeUnit.SECONDS
+    ) {
+        webhookClient.updateStatus(jibriStatusManager.overallStatus)
+    }
+
+    val cleanupAndExit = { exitCode: Int ->
+        statusUpdaterTask.cancel(true)
+        try {
+            statusUpdaterTask.get(5, TimeUnit.SECONDS)
+        } catch (t: Throwable) {
+            logger.error("Error cleaning up status updater task")
+        }
+        exitProcess(0)
+    }
+
     val configChangedHandler = {
         logger.info("The config file has changed, waiting for Jibri to be idle before exiting")
         jibriManager.executeWhenIdle {
             logger.info("Jibri is idle and there are config file changes, exiting")
             // Exit so we can be restarted and load the new config
-            exitProcess(0)
+            cleanupAndExit(0)
         }
     }
     val gracefulShutdownHandler = {
@@ -130,15 +155,17 @@ fun main(args: Array<String>) {
         jibriManager.executeWhenIdle {
             logger.info("Jibri is idle and has been told to gracefully shutdown, exiting")
             // Exit with code 255 to indicate we do not want process restart
-            exitProcess(255)
+            cleanupAndExit(255)
         }
     }
     val shutdownHandler = {
         logger.info("Jibri has been told to shutdown, stopping any active service")
         jibriManager.stopService()
         logger.info("Service stopped")
-        exitProcess(255)
+        cleanupAndExit(255)
     }
+
+    // InternalHttpApi
     val internalHttpApi = InternalHttpApi(
         configChangedHandler = configChangedHandler,
         gracefulShutdownHandler = gracefulShutdownHandler,

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -127,8 +127,8 @@ fun main(args: Array<String>) {
     }
     jibriConfig.webhookSubscribers.forEach { webhookClient.addSubscriber(it) }
     val statusUpdaterTask = TaskPools.recurringTasksPool.scheduleAtFixedRate(
-        30,
-        TimeUnit.SECONDS
+        1,
+        TimeUnit.MINUTES
     ) {
         webhookClient.updateStatus(jibriStatusManager.overallStatus)
     }

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -94,6 +94,12 @@ data class XmppEnvironmentConfig(
 )
 
 data class JibriConfig(
+    // NOTE(brian): this field should be considered required, but has a default
+    // for now to not break upgrades
+    @JsonProperty("jibri_id")
+    val jibriId: String = "",
+    @JsonProperty("webhook_subscribers")
+    val webhookSubscribers: List<String> = listOf(),
     @JsonProperty("recording_directory")
     val recordingDirectory: String,
     /**

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/Events.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/Events.kt
@@ -1,3 +1,5 @@
+// ktlint-disable filename
+
 /*
  * Copyright @ 2018 - present 8x8, Inc.
  *

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/Events.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/Events.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.webhooks.v1
+
+import org.jitsi.jibri.status.JibriStatus
+
+sealed class JibriEvent(val jibriId: String) {
+    class HealthEvent(jibriId: String, val status: JibriStatus) : JibriEvent(jibriId)
+}

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/README.md
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/README.md
@@ -1,0 +1,46 @@
+# Jibri 'Webhooks'
+
+Jibri supports being configured with a list of base URLs on which it will hit certain endpoints with data.  These are
+not "true" webhooks as the endpoints are hard-coded, instead Jibri defines a "contract" which it expect a subscriber
+to implement at the given base URL.  Information about this contract is below.
+
+### Status updates
+Jibri pushes status updates consisting of its "busy status" (whether it is busy or idle) and its health.
+
+URL: `/v1/status`
+
+method: `POST`
+
+Data constraints:
+```$json
+{
+    "jibriId":"[String]",
+    "status":{
+        "busyStatus":"[a String value of ComponentBusyStatus: (BUSY|IDLE|EXPIRED)]",
+        "health": {
+            "healthStatus":"[a String value of ComponentHealthStatus: (HEALTHY|UNHEALTHY)",
+            "details": [A map of String to ComponentHealthDetails giving optional details of sub-component's health]
+        }
+    }
+}
+```
+
+Data example:
+```$json
+{
+    "jibriId":"jibri_id",
+    "status":{
+        "busyStatus":"IDLE",
+        "health":{
+            "healthStatus":"HEALTHY",
+            "details":{}
+        }
+    }
+}
+```
+
+Success response:
+
+Code: `200 OK`
+
+Data: body will be ignored

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/README.md
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/README.md
@@ -5,7 +5,8 @@ not "true" webhooks as the endpoints are hard-coded, instead Jibri defines a "co
 to implement at the given base URL.  Information about this contract is below.
 
 ### Status updates
-Jibri pushes status updates consisting of its "busy status" (whether it is busy or idle) and its health.
+Jibri pushes status updates consisting of its "busy status" (whether it is busy or idle) and its health.  These updates
+are sent periodically every minute and every time the status changes.
 
 URL: `/v1/status`
 

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -20,6 +20,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.apache.Apache
 import io.ktor.client.features.json.JacksonSerializer
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.request.HttpRequestBuilder
@@ -55,6 +56,7 @@ class WebhookClient private constructor(
     }
 
     fun updateStatus(status: JibriStatus) = runBlocking {
+        logger.debug("Updating subscribers of status")
         webhookSubscribers.forEach { subscriberBaseUrl ->
             launch {
                 logger.debug("Sending request to $subscriberBaseUrl")
@@ -83,6 +85,15 @@ class WebhookClient private constructor(
         ): WebhookClient {
             val client = HttpClient(engineFactory) {
                 block()
+                install(JsonFeature) {
+                    serializer = JacksonSerializer()
+                }
+            }
+            return WebhookClient(jibriId, client)
+        }
+
+        operator fun invoke(jibriId: String): WebhookClient {
+            val client = HttpClient(Apache) {
                 install(JsonFeature) {
                     serializer = JacksonSerializer()
                 }

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -31,7 +31,6 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.webhooks.v1
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.apache.Apache
+import io.ktor.client.features.json.JacksonSerializer
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.jitsi.jibri.status.JibriStatus
+
+class WebhookClient() {
+    private val client = HttpClient(Apache) {
+        install(JsonFeature) {
+            serializer = JacksonSerializer()
+        }
+    }
+
+    private val webhookSubscribers = mutableListOf<String>()
+
+    fun updateStatus(status: JibriStatus) = runBlocking {
+        webhookSubscribers.forEach { subscriberBaseUrl ->
+            launch {
+                val resp = client.postJson<HttpResponse>("$subscriberBaseUrl/health")
+                if (resp.status != HttpStatusCode.OK) {
+                    println("Error updating webhook subscriber $subscriberBaseUrl: $resp")
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Just like [HttpClient.post], but automatically sets the content type to
+ * [ContentType.Application.Json].
+ */
+private suspend inline fun <reified T> HttpClient.postJson(
+    urlString: String,
+    block: HttpRequestBuilder.() -> Unit = {}
+): T = post {
+    post<T>(urlString) {
+        block()
+        contentType(ContentType.Application.Json)
+    }
+}

--- a/src/test/kotlin/org/jitsi/jibri/config/JibriConfigTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/config/JibriConfigTest.kt
@@ -36,7 +36,6 @@ class JibriConfigTest : ShouldSpec({
     }
 })
 
-
 private val requiredOnly: String = """
     {
         "recording_directory": "some/recording/dir",

--- a/src/test/kotlin/org/jitsi/jibri/config/JibriConfigTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/config/JibriConfigTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.config
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+class JibriConfigTest : ShouldSpec({
+    context("parsing a config") {
+        context("with optional keys missing") {
+            val config = jacksonObjectMapper().readValue<JibriConfig>(requiredOnly)
+            should("use the default values") {
+                config.jibriId shouldBe ""
+                config.webhookSubscribers.shouldBeEmpty()
+                config.singleUseMode shouldBe false
+                config.enabledStatsD shouldBe true
+            }
+        }
+    }
+})
+
+
+private val requiredOnly: String = """
+    {
+        "recording_directory": "some/recording/dir",
+        "finalize_recording_script_path": "path/to/finalize",
+        "xmpp_environments": []
+    }
+""".trimIndent()

--- a/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.webhooks.v1
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.request.HttpRequestData
+import kotlinx.coroutines.delay
+import io.ktor.content.TextContent
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import org.jitsi.jibri.status.ComponentBusyStatus
+import org.jitsi.jibri.status.ComponentHealthStatus
+import org.jitsi.jibri.status.JibriStatus
+import org.jitsi.jibri.status.OverallHealth
+
+class WebhookClientTest : ShouldSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val requests = mutableListOf<HttpRequestData>()
+    val goodStatus = JibriStatus(
+        ComponentBusyStatus.IDLE,
+        OverallHealth(
+            ComponentHealthStatus.HEALTHY,
+            mapOf()
+        )
+    )
+    val badStatus = JibriStatus(
+        ComponentBusyStatus.IDLE,
+        OverallHealth(
+            ComponentHealthStatus.UNHEALTHY,
+            mapOf()
+        )
+    )
+    val client = WebhookClient("test", MockEngine) {
+        engine {
+            addHandler { request ->
+                requests += request
+                with (request.url.toString()) {
+                    when {
+                        contains("success") -> {
+                            respondOk()
+                        }
+                        contains("delay") -> {
+                            delay(1000)
+                            respondOk()
+                        }
+                        contains("error") -> {
+                            respondError(HttpStatusCode.BadRequest)
+                        }
+                        else -> error("Unsupported URL")
+                    }
+                }
+            }
+        }
+    }
+    context("when the client") {
+        context("has a valid subscriber") {
+            client.addSubscriber("success")
+            context("calling updateStatus") {
+                client.updateStatus(goodStatus)
+                should("send a POST to the subscriber at the proper url") {
+                    requests shouldHaveSize  1
+                    with (requests[0]) {
+                        url.toString() shouldContain "/v1/health"
+                        method shouldBe HttpMethod.Post
+                    }
+                }
+                should("send the correct data") {
+                    requests[0].body.contentType shouldBe ContentType.Application.Json
+                    requests[0].body.shouldBeInstanceOf<TextContent> {
+                        it.text shouldBe jacksonObjectMapper().writeValueAsString(
+                            JibriEvent.HealthEvent("test", goodStatus)
+                        )
+                        it.text shouldContain """
+                            "jibriId":"test"
+                        """.trimIndent()
+                    }
+                }
+                context("and calling updateStatus again") {
+                    client.updateStatus(badStatus)
+                    should("send another request with the new status") {
+                        requests shouldHaveSize 2
+                        requests[1].body.shouldBeInstanceOf<TextContent> {
+                            it.text shouldContain jacksonObjectMapper().writeValueAsString(
+                                JibriEvent.HealthEvent("test", badStatus)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        context("has multiple subscribers") {
+            client.addSubscriber("https://success")
+            client.addSubscriber("https://delay")
+            client.addSubscriber("https://error")
+            context("calling updateStatus") {
+                client.updateStatus(goodStatus)
+                should("send a POST to the subscribers at the proper url") {
+                    requests shouldHaveSize 3
+                    requests shouldContainRequestTo "success"
+                    requests shouldContainRequestTo "delay"
+                    requests shouldContainRequestTo "error"
+                }
+                context("and calling updateStatus again") {
+                    requests.clear()
+                    client.updateStatus(goodStatus)
+                    should("send a POST to the subscribers at the proper url") {
+                        requests shouldHaveSize 3
+                        requests shouldContainRequestTo "success"
+                        requests shouldContainRequestTo "delay"
+                        requests shouldContainRequestTo "error"
+                    }
+                }
+            }
+        }
+    }
+})
+
+infix fun List<HttpRequestData>.shouldContainRequestTo(host: String) {
+    this.find { it.url.host.contains(host) } shouldNotBe null
+}
+
+fun MockEngineConfig.addNotifyingHandler(handler: MockRequestHandler) {
+    requestHandlers += handler
+}

--- a/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
@@ -30,11 +30,11 @@ import io.ktor.client.engine.mock.MockRequestHandler
 import io.ktor.client.engine.mock.respondError
 import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.request.HttpRequestData
-import kotlinx.coroutines.delay
 import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.delay
 import org.jitsi.jibri.status.ComponentBusyStatus
 import org.jitsi.jibri.status.ComponentHealthStatus
 import org.jitsi.jibri.status.JibriStatus
@@ -61,7 +61,7 @@ class WebhookClientTest : ShouldSpec({
         engine {
             addHandler { request ->
                 requests += request
-                with (request.url.toString()) {
+                with(request.url.toString()) {
                     when {
                         contains("success") -> {
                             respondOk()
@@ -85,8 +85,8 @@ class WebhookClientTest : ShouldSpec({
             context("calling updateStatus") {
                 client.updateStatus(goodStatus)
                 should("send a POST to the subscriber at the proper url") {
-                    requests shouldHaveSize  1
-                    with (requests[0]) {
+                    requests shouldHaveSize 1
+                    with(requests[0]) {
                         url.toString() shouldContain "/v1/status"
                         method shouldBe HttpMethod.Post
                     }

--- a/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
@@ -87,7 +87,7 @@ class WebhookClientTest : ShouldSpec({
                 should("send a POST to the subscriber at the proper url") {
                     requests shouldHaveSize  1
                     with (requests[0]) {
-                        url.toString() shouldContain "/v1/health"
+                        url.toString() shouldContain "/v1/status"
                         method shouldBe HttpMethod.Post
                     }
                 }


### PR DESCRIPTION
This PR adds a new 'webhook' for consumers to be able to get updates on Jibri's status.  There are accompanying configuration changes, but all new config keys have default values so upgrades shouldn't break (the `jibri_id` key will likely have its default value removed eventually).

This implementation is more of a 'pseudo' webhook, as there is no dynamic registration (webhook consumers must have their base URLs configured in the config file) and the callback URL is not customizable, instead it is assumed that, at the configured base URL, a 'contract' (currently of only a single method) defined by Jibri is implemented.  There's a README containing more information.