### PR TITLE
Port HTTP APIs to ktor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,36 +87,6 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-jetty-http</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>
             <artifactId>argparse4j</artifactId>
             <version>0.8.1</version>
@@ -233,12 +203,6 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>1.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jetty</artifactId>
-            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,21 @@
             <artifactId>ktor-client-jackson</artifactId>
             <version>${ktor.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-server-core</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-server-jetty</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-jackson</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>
@@ -206,6 +221,12 @@
             <groupId>io.ktor</groupId>
             <artifactId>ktor-client-mock-jvm</artifactId>
             <version>${ktor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-server-test-host</artifactId>
+            <version>${ktor.version}</version>
+            <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->
         <dependency>

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -18,23 +18,15 @@
 package org.jitsi.jibri
 
 import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.jetty.Jetty
 import kotlinx.coroutines.CancellationException
 import net.sourceforge.argparse4j.ArgumentParsers
-import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.servlet.ServletContextHandler
-import org.eclipse.jetty.servlet.ServletHolder
-import org.glassfish.jersey.jackson.JacksonFeature
-import org.glassfish.jersey.server.ResourceConfig
-import org.glassfish.jersey.servlet.ServletContainer
 import org.jitsi.jibri.api.http.HttpApi
 import org.jitsi.jibri.api.http.internal.InternalHttpApi
 import org.jitsi.jibri.api.xmpp.XmppApi
@@ -50,7 +42,6 @@ import org.jitsi.jibri.webhooks.v1.WebhookClient
 import java.io.File
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
-import javax.ws.rs.ext.ContextResolver
 import kotlin.system.exitProcess
 
 val logger: Logger = Logger.getLogger("org.jitsi.jibri.Main")
@@ -172,7 +163,7 @@ fun main(args: Array<String>) {
         cleanupAndExit(255)
     }
 
-    with (InternalHttpApi(configChangedHandler, gracefulShutdownHandler, shutdownHandler)) {
+    with(InternalHttpApi(configChangedHandler, gracefulShutdownHandler, shutdownHandler)) {
         embeddedServer(Jetty, port = internalHttpPort) {
             internalApiModule()
         }.start()

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -187,20 +187,9 @@ fun main(args: Array<String>) {
     xmppApi.start()
 
     // HttpApi
-    launchHttpServer(httpApiPort, HttpApi(jibriManager, jibriStatusManager))
-}
-
-fun launchHttpServer(port: Int, component: Any) {
-    val jerseyConfig = ResourceConfig(object : ResourceConfig() {
-        init {
-            register(ContextResolver<ObjectMapper> { ObjectMapper().registerKotlinModule() })
-            register(JacksonFeature::class.java)
-            registerInstances(component)
+    with(HttpApi(jibriManager, jibriStatusManager)) {
+        embeddedServer(Jetty, port = httpApiPort) {
+            apiModule()
         }
-    })
-    val servlet = ServletHolder(ServletContainer(jerseyConfig))
-    val server = Server(port)
-    val context = ServletContextHandler(server, "/*")
-    context.addServlet(servlet, "/*")
-    server.start()
+    }.start()
 }

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -36,7 +36,7 @@ import org.glassfish.jersey.jackson.JacksonFeature
 import org.glassfish.jersey.server.ResourceConfig
 import org.glassfish.jersey.servlet.ServletContainer
 import org.jitsi.jibri.api.http.HttpApi
-import org.jitsi.jibri.api.http.internal.internalApiModule
+import org.jitsi.jibri.api.http.internal.InternalHttpApi
 import org.jitsi.jibri.api.xmpp.XmppApi
 import org.jitsi.jibri.config.JibriConfig
 import org.jitsi.jibri.statsd.JibriStatsDClient
@@ -172,10 +172,11 @@ fun main(args: Array<String>) {
         cleanupAndExit(255)
     }
 
-    // InternalHttpApi
-    embeddedServer(Jetty, port = internalHttpPort) {
-        internalApiModule(configChangedHandler, gracefulShutdownHandler, shutdownHandler)
-    }.start()
+    with (InternalHttpApi(configChangedHandler, gracefulShutdownHandler, shutdownHandler)) {
+        embeddedServer(Jetty, port = internalHttpPort) {
+            internalApiModule()
+        }.start()
+    }
 
     // XmppApi
     val xmppApi = XmppApi(

--- a/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright @ 2018 Atlassian Pty Ltd
+ * Copyright @ 2018 - present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,11 +12,22 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.jitsi.jibri.api.http
 
+import io.ktor.application.Application
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.features.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.jackson.jackson
+import io.ktor.request.receive
+import io.ktor.response.respond
+import io.ktor.routing.get
+import io.ktor.routing.post
+import io.ktor.routing.route
+import io.ktor.routing.routing
 import org.jitsi.jibri.FileRecordingRequestParams
 import org.jitsi.jibri.JibriBusyException
 import org.jitsi.jibri.JibriManager
@@ -31,12 +42,6 @@ import org.jitsi.jibri.sipgateway.SipClientParams
 import org.jitsi.jibri.status.JibriStatusManager
 import org.jitsi.jibri.util.extensions.debug
 import java.util.logging.Logger
-import javax.ws.rs.Consumes
-import javax.ws.rs.GET
-import javax.ws.rs.POST
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
-import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 // TODO: this needs to include usageTimeout
@@ -57,117 +62,112 @@ data class StartServiceParams(
     val sipClientParams: SipClientParams? = null
 )
 
-/**
- * The [HttpApi] is for starting and stopping the various Jibri services via the
- * [JibriManager], as well as retrieving the health and status of this Jibri
- */
-@Path("/jibri/api/v1.0")
 class HttpApi(
     private val jibriManager: JibriManager,
     private val jibriStatusManager: JibriStatusManager
 ) {
     private val logger = Logger.getLogger(this::class.qualifiedName)
 
-    /**
-     * Get the health of this Jibri in the format of a json-encoded
-     * [org.jitsi.jibri.health.JibriHealth] object
-     */
-    @GET
-    @Path("health")
-    @Produces(MediaType.APPLICATION_JSON)
-    fun health(): Response {
-        logger.debug("Got health request")
-        val health = JibriHealth(jibriStatusManager.overallStatus, jibriManager.currentEnvironmentContext)
-        logger.debug("Returning health $health")
-        return Response.ok(health).build()
-    }
+    fun Application.apiModule() {
+        install(ContentNegotiation) {
+            jackson {}
+        }
 
-    /**
-     * [startService] will start a new service using the given [StartServiceParams].
-     * Returns a response with [Response.Status.OK] on success, [Response.Status.PRECONDITION_FAILED]
-     * if this Jibri is already busy and [Response.Status.INTERNAL_SERVER_ERROR] on error
-     * NOTE: start service is largely async, so a return of [Response.Status.OK] here just means Jibri
-     * was able to *try* to start the request.  We don't have a way to get ongoing updates about services
-     * via the HTTP API at this point.
-     */
-    @POST
-    @Path("startService")
-    @Consumes(MediaType.APPLICATION_JSON)
-    fun startService(startServiceParams: StartServiceParams): Response {
-        logger.debug("Got a start service request with params $startServiceParams")
-        // A wrapper around a service's start call to handle errors
-        val serviceLauncher: (() -> Unit) -> Response = { block ->
-            try {
-                block()
-                Response.ok().build()
-            } catch (e: JibriBusyException) {
-                Response.status(Response.Status.PRECONDITION_FAILED).build()
-            } catch (t: Throwable) {
-                Response.status(Response.Status.INTERNAL_SERVER_ERROR).build()
+        routing {
+            route("jibri/api/v1.0") {
+                /**
+                 * Get the health of this Jibri in the format of a json-encoded
+                 * [JibriHealth] object
+                 */
+                get("health") {
+                    logger.debug("Got health request")
+                    val health = JibriHealth(jibriStatusManager.overallStatus, jibriManager.currentEnvironmentContext)
+                    logger.debug("Returning health $health")
+                    call.respond(health)
+                }
+
+                /**
+                 * Start a new service using the given [StartServiceParams].
+                 * Returns a response with [Response.Status.OK] on success, [Response.Status.PRECONDITION_FAILED]
+                 * if this Jibri is already busy or params were missing and [Response.Status.INTERNAL_SERVER_ERROR] on
+                 * error
+                 * NOTE: start service is largely async, so a return of [Response.Status.OK] here just means Jibri
+                 * was able to *try* to start the request.  We don't have a way to get ongoing updates about services
+                 * via the HTTP API at this point.
+                 */
+                post("startService") {
+                    val startServiceParams = call.receive<StartServiceParams>()
+                    logger.debug("Got a start service request with params $startServiceParams")
+                    try {
+                        handleStartService(startServiceParams)
+                        call.respond(HttpStatusCode.OK)
+                    } catch (e: JibriBusyException) {
+                        call.respond(HttpStatusCode.PreconditionFailed, "Jibri is currently busy")
+                    } catch (e: IllegalStateException) {
+                        call.respond(HttpStatusCode.PreconditionFailed, e.message ?: "")
+                    } catch (t: Throwable) {
+                        call.respond(HttpStatusCode.InternalServerError)
+                    }
+                }
+
+                /**
+                 * [stopService] will stop the current service immediately
+                 */
+                post("stopService") {
+                    logger.debug("Got stop service request")
+                    jibriManager.stopService()
+                    call.respond(HttpStatusCode.OK)
+                }
             }
         }
-        return when (startServiceParams.sinkType) {
+    }
+
+    private fun handleStartService(startServiceParams: StartServiceParams) {
+        when (startServiceParams.sinkType) {
             RecordingSinkType.FILE -> {
                 // If it's a file recording, it must have the callLoginParams set
                 val callLoginParams = startServiceParams.callLoginParams
-                    ?: return Response.status(Response.Status.PRECONDITION_FAILED).build()
-                serviceLauncher {
-                    jibriManager.startFileRecording(
-                            ServiceParams(usageTimeoutMinutes = 0),
-                            FileRecordingRequestParams(
-                                startServiceParams.callParams,
-                                startServiceParams.sessionId,
-                                callLoginParams
-                            ),
-                            environmentContext = null
-                    )
-                }
+                    ?: throw IllegalStateException("Call login params missing")
+                jibriManager.startFileRecording(
+                    ServiceParams(usageTimeoutMinutes = 0),
+                    FileRecordingRequestParams(
+                        startServiceParams.callParams,
+                        startServiceParams.sessionId,
+                        callLoginParams
+                    ),
+                    environmentContext = null
+                )
             }
             RecordingSinkType.STREAM -> {
                 val youTubeStreamKey = startServiceParams.youTubeStreamKey
-                    ?: return Response.status(Response.Status.PRECONDITION_FAILED).build()
+                    ?: throw IllegalStateException("Stream key missing")
                 // If it's a stream, it must have the callLoginParams set
                 val callLoginParams = startServiceParams.callLoginParams
-                    ?: return Response.status(Response.Status.PRECONDITION_FAILED).build()
-                serviceLauncher {
-                    jibriManager.startStreaming(
-                            ServiceParams(usageTimeoutMinutes = 0),
-                            StreamingParams(
-                                startServiceParams.callParams,
-                                startServiceParams.sessionId,
-                                callLoginParams,
-                                youTubeStreamKey
-                            ),
-                            environmentContext = null
-                    )
-                }
+                    ?: throw IllegalStateException("Call login params missing")
+                jibriManager.startStreaming(
+                    ServiceParams(usageTimeoutMinutes = 0),
+                    StreamingParams(
+                        startServiceParams.callParams,
+                        startServiceParams.sessionId,
+                        callLoginParams,
+                        youTubeStreamKey
+                    ),
+                    environmentContext = null
+                )
             }
             RecordingSinkType.GATEWAY -> {
                 // If it's a sip gateway, it must have sipClientParams set
                 val sipClientParams = startServiceParams.sipClientParams
-                    ?: return Response.status(Response.Status.PRECONDITION_FAILED).build()
-                serviceLauncher {
-                    jibriManager.startSipGateway(
-                            ServiceParams(usageTimeoutMinutes = 0),
-                            // TODO: add session ID
-                            SipGatewayServiceParams(
-                                    startServiceParams.callParams,
-                                    startServiceParams.callLoginParams,
-                                    sipClientParams)
-                    )
-                }
+                    ?: throw IllegalStateException("SIP client params missing")
+                jibriManager.startSipGateway(
+                    ServiceParams(usageTimeoutMinutes = 0),
+                    // TODO: add session ID
+                    SipGatewayServiceParams(
+                        startServiceParams.callParams,
+                        startServiceParams.callLoginParams,
+                        sipClientParams)
+                )
             }
         }
-    }
-
-    /**
-     * [stopService] will stop the current service immediately
-     */
-    @POST
-    @Path("stopService")
-    fun stopService(): Response {
-        logger.debug("Got stop service request")
-        jibriManager.stopService()
-        return Response.ok().build()
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApi.kt
@@ -33,44 +33,46 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.util.logging.Logger
 
-fun Application.internalApiModule(
-    configChangedHandler: () -> Unit,
-    gracefulShutdownHandler: () -> Unit,
-    shutdownHandler: () -> Unit
+class InternalHttpApi(
+    private val configChangedHandler: () -> Unit,
+    private val gracefulShutdownHandler: () -> Unit,
+    private val shutdownHandler: () -> Unit
 ) {
-    install(ContentNegotiation) {
-        jackson {}
-    }
+    private val logger = Logger.getLogger(this::class.qualifiedName)
 
-    val logger = Logger.getLogger("org.jitsi.jibri.api.http.internal.InternalHttpApi")
+    fun Application.internalApiModule() {
+        install(ContentNegotiation) {
+            jackson {}
+        }
 
-    routing {
-        route("/jibri/api/internal/v1.0") {
-            /**
-             * Signal this Jibri to shutdown gracefully, meaning shut down when
-             * it is idle (i.e. finish any currently running service). Returns a 200
-             * and schedules a shutdown for when it becomes idle.
-             */
-            post("gracefulShutdown") {
-                logger.info("Jibri gracefully shutting down")
-                respondOkAndRun(gracefulShutdownHandler)
-            }
-            /**
-             * Signal this Jibri to reload its config file at the soonest opportunity
-             * (when it does not have a currently running service). Returns a 200
-             */
-            post("notifyConfigChanged") {
-                logger.info("Config file changed")
-                respondOkAndRun(configChangedHandler)
-            }
-            /**
-             * Signal this Jibri to (cleanly) stop any services that are
-             * running and shutdown.  Returns a 200 and schedules a shutdown with a 1
-             * second delay.
-             */
-            post("shutdown") {
-                logger.info("Jibri is forcefully shutting down")
-                respondOkAndRun(shutdownHandler)
+        routing {
+            route("/jibri/api/internal/v1.0") {
+                /**
+                 * Signal this Jibri to shutdown gracefully, meaning shut down when
+                 * it is idle (i.e. finish any currently running service). Returns a 200
+                 * and schedules a shutdown for when it becomes idle.
+                 */
+                post("gracefulShutdown") {
+                    logger.info("Jibri gracefully shutting down")
+                    respondOkAndRun(gracefulShutdownHandler)
+                }
+                /**
+                 * Signal this Jibri to reload its config file at the soonest opportunity
+                 * (when it does not have a currently running service). Returns a 200
+                 */
+                post("notifyConfigChanged") {
+                    logger.info("Config file changed")
+                    respondOkAndRun(configChangedHandler)
+                }
+                /**
+                 * Signal this Jibri to (cleanly) stop any services that are
+                 * running and shutdown.  Returns a 200 and schedules a shutdown with a 1
+                 * second delay.
+                 */
+                post("shutdown") {
+                    logger.info("Jibri is forcefully shutting down")
+                    respondOkAndRun(shutdownHandler)
+                }
             }
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApi.kt
@@ -58,7 +58,7 @@ class InternalHttpApi(
                 }
                 /**
                  * Signal this Jibri to reload its config file at the soonest opportunity
-                 * (when it does not have a currently running service). Returns a 200
+                 * (when it does not have a currently running service). Returns a 200.
                  */
                 post("notifyConfigChanged") {
                     logger.info("Config file changed")
@@ -66,8 +66,7 @@ class InternalHttpApi(
                 }
                 /**
                  * Signal this Jibri to (cleanly) stop any services that are
-                 * running and shutdown.  Returns a 200 and schedules a shutdown with a 1
-                 * second delay.
+                 * running and shutdown.  Returns a 200.
                  */
                 post("shutdown") {
                     logger.info("Jibri is forcefully shutting down")

--- a/src/test/kotlin/org/jitsi/jibri/api/http/HttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/HttpApiTest.kt
@@ -112,7 +112,6 @@ class HttpApiTest : ShouldSpec() {
                             val health = jacksonObjectMapper().readValue(response.content, JibriHealth::class.java)
                             health shouldBe expectedHealth
                         }
-
                     }
                 }
             }
@@ -154,8 +153,8 @@ class HttpApiTest : ShouldSpec() {
             }
         }
     }
-    private fun<R> apiTest(block: TestApplicationEngine.() -> R) {
-        with (api) {
+    private fun <R> apiTest(block: TestApplicationEngine.() -> R) {
+        with(api) {
             io.ktor.server.testing.withTestApplication({
                 apiModule()
             }) {

--- a/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
@@ -17,72 +17,69 @@
 
 package org.jitsi.jibri.api.http.internal
 
-import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.clearMocks
-import io.mockk.every
-import io.mockk.mockk
-import org.jitsi.jibri.helpers.resetScheduledPool
-import org.jitsi.jibri.helpers.setScheduledPool
-import org.jitsi.jibri.util.TaskPools
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.withTestApplication
 
-class InternalHttpApiTest : ShouldSpec() {
-    private val executor: ScheduledExecutorService = mockk()
-    private val future: ScheduledFuture<*> = mockk()
+class InternalHttpApiTest : FunSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
 
-    init {
-        beforeSpec {
-            TaskPools.setScheduledPool(executor)
-        }
+    var gracefulShutdownHandlerCalls = 0
+    var shutdownHandlerCalls = 0
+    var configChangedHandlerCalls = 0
 
-        beforeTest {
-            clearMocks(executor, future)
-            every { executor.schedule(any(), any(), any()) } returns future
-        }
-
-        afterSpec {
-            TaskPools.resetScheduledPool()
-        }
-
-        context("gracefulShutdown") {
-            should("return a 200 and not invoke the shutdown handler directly") {
-                var gracefulShutdownHandlerCalled = false
-                val gracefulShutdownHandler = {
-                    gracefulShutdownHandlerCalled = true
-                }
-                val internalHttpApi = InternalHttpApi({}, gracefulShutdownHandler, {})
-                val response = internalHttpApi.gracefulShutdown()
-                response.status shouldBe 200
-                gracefulShutdownHandlerCalled shouldBe false
-            }
-        }
-
-        context("notifyConfigChanged") {
-            should("return a 200 and not invoke the config changed handler directly") {
-                var configChangedHandlerCalled = false
-                val configChangedHandler = {
-                    configChangedHandlerCalled = true
-                }
-                val internalHttpApi = InternalHttpApi({}, configChangedHandler, {})
-                val response = internalHttpApi.reloadConfig()
-                response.status shouldBe 200
-                configChangedHandlerCalled shouldBe false
-            }
-        }
-
-        context("shutdown") {
-            should("return a 200 and not invoke the shutdown handler directly") {
-                var shutdownHandlerCalled = false
-                val shutdownHandler = {
-                    shutdownHandlerCalled = true
-                }
-                val internalHttpApi = InternalHttpApi({}, {}, shutdownHandler)
-                val response = internalHttpApi.shutdown()
-                response.status shouldBe 200
-                shutdownHandlerCalled shouldBe false
+    test("gracefulShutdown should return a 200 and invoke the graceful shutdown handler") {
+        withTestApplication({
+            internalApiModule(
+                configChangedHandler = { configChangedHandlerCalls++ },
+                gracefulShutdownHandler = { gracefulShutdownHandlerCalls++ },
+                shutdownHandler = { shutdownHandlerCalls++ }
+            )
+        }) {
+            with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/gracefulShutdown")) {
+                response.status() shouldBe HttpStatusCode.OK
+                gracefulShutdownHandlerCalls shouldBe 1
+                configChangedHandlerCalls shouldBe 0
+                shutdownHandlerCalls shouldBe 0
             }
         }
     }
-}
+
+    test("notifyConfigChanged should return a 200 and invoke the config changed handler") {
+        withTestApplication({
+            internalApiModule(
+                configChangedHandler = { configChangedHandlerCalls++ },
+                gracefulShutdownHandler = { gracefulShutdownHandlerCalls++ },
+                shutdownHandler = { shutdownHandlerCalls++ }
+            )
+        }) {
+            with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/notifyConfigChanged")) {
+                response.status() shouldBe HttpStatusCode.OK
+                gracefulShutdownHandlerCalls shouldBe 0
+                configChangedHandlerCalls shouldBe 1
+                shutdownHandlerCalls shouldBe 0
+            }
+        }
+    }
+
+    test("shutdown should return a 200 and invoke the shutdown handler") {
+        withTestApplication({
+            internalApiModule(
+                configChangedHandler = { configChangedHandlerCalls++ },
+                gracefulShutdownHandler = { gracefulShutdownHandlerCalls++ },
+                shutdownHandler = { shutdownHandlerCalls++ }
+            )
+        }) {
+            with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/shutdown")) {
+                response.status() shouldBe HttpStatusCode.OK
+                gracefulShutdownHandlerCalls shouldBe 0
+                configChangedHandlerCalls shouldBe 0
+                shutdownHandlerCalls shouldBe 1
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
@@ -74,8 +74,8 @@ class InternalHttpApiTest : FunSpec() {
             }
         }
     }
-    private fun<R> apiTest(block: TestApplicationEngine.() -> R) {
-        with (internalApi) {
+    private fun <R> apiTest(block: TestApplicationEngine.() -> R) {
+        with(internalApi) {
             withTestApplication({
                 internalApiModule()
             }) {
@@ -84,5 +84,3 @@ class InternalHttpApiTest : FunSpec() {
         }
     }
 }
-
-

--- a/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApiTest.kt
@@ -22,64 +22,67 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 
-class InternalHttpApiTest : FunSpec({
-    isolationMode = IsolationMode.InstancePerLeaf
+class InternalHttpApiTest : FunSpec() {
 
-    var gracefulShutdownHandlerCalls = 0
-    var shutdownHandlerCalls = 0
-    var configChangedHandlerCalls = 0
+    private var gracefulShutdownHandlerCalls = 0
+    private var shutdownHandlerCalls = 0
+    private var configChangedHandlerCalls = 0
 
-    test("gracefulShutdown should return a 200 and invoke the graceful shutdown handler") {
-        withTestApplication({
-            internalApiModule(
-                configChangedHandler = { configChangedHandlerCalls++ },
-                gracefulShutdownHandler = { gracefulShutdownHandlerCalls++ },
-                shutdownHandler = { shutdownHandlerCalls++ }
-            )
-        }) {
-            with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/gracefulShutdown")) {
-                response.status() shouldBe HttpStatusCode.OK
-                gracefulShutdownHandlerCalls shouldBe 1
-                configChangedHandlerCalls shouldBe 0
-                shutdownHandlerCalls shouldBe 0
+    private val internalApi = InternalHttpApi(
+        { configChangedHandlerCalls++ },
+        { gracefulShutdownHandlerCalls++ },
+        { shutdownHandlerCalls++ }
+    )
+
+    init {
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        test("gracefulShutdown should return a 200 and invoke the graceful shutdown handler") {
+            apiTest {
+                with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/gracefulShutdown")) {
+                    response.status() shouldBe HttpStatusCode.OK
+                    gracefulShutdownHandlerCalls shouldBe 1
+                    configChangedHandlerCalls shouldBe 0
+                    shutdownHandlerCalls shouldBe 0
+                }
+            }
+        }
+
+        test("notifyConfigChanged should return a 200 and invoke the config changed handler") {
+            apiTest {
+                with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/notifyConfigChanged")) {
+                    response.status() shouldBe HttpStatusCode.OK
+                    gracefulShutdownHandlerCalls shouldBe 0
+                    configChangedHandlerCalls shouldBe 1
+                    shutdownHandlerCalls shouldBe 0
+                }
+            }
+        }
+
+        test("shutdown should return a 200 and invoke the shutdown handler") {
+            apiTest {
+                with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/shutdown")) {
+                    response.status() shouldBe HttpStatusCode.OK
+                    gracefulShutdownHandlerCalls shouldBe 0
+                    configChangedHandlerCalls shouldBe 0
+                    shutdownHandlerCalls shouldBe 1
+                }
             }
         }
     }
-
-    test("notifyConfigChanged should return a 200 and invoke the config changed handler") {
-        withTestApplication({
-            internalApiModule(
-                configChangedHandler = { configChangedHandlerCalls++ },
-                gracefulShutdownHandler = { gracefulShutdownHandlerCalls++ },
-                shutdownHandler = { shutdownHandlerCalls++ }
-            )
-        }) {
-            with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/notifyConfigChanged")) {
-                response.status() shouldBe HttpStatusCode.OK
-                gracefulShutdownHandlerCalls shouldBe 0
-                configChangedHandlerCalls shouldBe 1
-                shutdownHandlerCalls shouldBe 0
+    private fun<R> apiTest(block: TestApplicationEngine.() -> R) {
+        with (internalApi) {
+            withTestApplication({
+                internalApiModule()
+            }) {
+                block()
             }
         }
     }
+}
 
-    test("shutdown should return a 200 and invoke the shutdown handler") {
-        withTestApplication({
-            internalApiModule(
-                configChangedHandler = { configChangedHandlerCalls++ },
-                gracefulShutdownHandler = { gracefulShutdownHandlerCalls++ },
-                shutdownHandler = { shutdownHandlerCalls++ }
-            )
-        }) {
-            with(handleRequest(HttpMethod.Post, "/jibri/api/internal/v1.0/shutdown")) {
-                response.status() shouldBe HttpStatusCode.OK
-                gracefulShutdownHandlerCalls shouldBe 0
-                configChangedHandlerCalls shouldBe 0
-                shutdownHandlerCalls shouldBe 1
-            }
-        }
-    }
-})
+


### PR DESCRIPTION
This PR ports the HTTP API code away from Jetty and over to Ktor.  Jetty was pretty heavyweight and we ran into multiple issues with the injection framework causing problems on different Java versions.  Ktor also allows getting rid of an awkward chunk of code around handling a request for shutdown (we no longer need to schedule a task for 1ms from now to do the shutdown so we can ensure the response gets sent, as Ktor allows for a cleaner way).  We also now use Ktor for the HTTP client code (for the webhooks) so this unifies things.