### PR TITLE
Fix groupId for statemachine dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>com.github.tinder</groupId>
+            <groupId>com.tinder.statemachine</groupId>
             <artifactId>statemachine</artifactId>
             <version>0.2.0</version>
         </dependency>


### PR DESCRIPTION
The jibri package cannot be build with maven anymore:

```bash
$ mvn dependency\:analyze
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------------------< org.jitsi:jibri >---------------------------
[INFO] Building jibri 8.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] >>> maven-dependency-plugin:2.8:analyze (default-cli) > test-compile @ jibri >>>
Downloading from jitpack.io: https://jitpack.io/com/github/tinder/statemachine/0.2.0/statemachine-0.2.0.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.013 s
[INFO] Finished at: 2020-07-20T13:11:58+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project jibri: Could not resolve dependencies for project org.jitsi:jibri:jar:8.0-SNAPSHOT: Failed to collect dependencies at com.github.tinder:statemachine:jar:0.2.0: Failed to read artifact descriptor for com.github.tinder:statemachine:jar:0.2.0: Could not transfer artifact com.github.tinder:statemachine:pom:0.2.0 from/to jitpack.io (https://jitpack.io): NullPointerException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```
According to the [mvn repository](https://mvnrepository.com/artifact/com.tinder.statemachine/statemachine/0.2.0) the `groupId` in the jibri POM file is wrong. This commit fixes the `groupId` and the package can be build again.