### PR TITLE
Fix too-soon timeout after clients unmute

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/MediaReceivedStatusCheck.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/MediaReceivedStatusCheck.kt
@@ -31,7 +31,9 @@ class MediaReceivedStatusCheck(
         logger.info("Jibri client receive bitrates: $bitrates, all clients muted? $allClientsMuted")
         clientsAllMutedTransitionTime.maybeUpdate(allClientsMuted)
         val downloadBitrate = bitrates.getOrDefault("download", 0L) as Long
-        if (downloadBitrate != 0L) {
+        // If all clients are muted, register it as 'receiving media': that way when clients unmute
+        // we'll get the full NO_MEDIA_TIMEOUT duration before timing out due to lack of media
+        if (downloadBitrate != 0L || allClientsMuted) {
             timeOfLastMedia = now
         }
         val timeSinceLastMedia = Duration.between(timeOfLastMedia, now)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright @ 2018 - present 8x8, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- Used to control mockk's debug log level for tests -->
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This PR fixes the following issue:

* If we haven’t seen media for longer than NO_MEDIA_TIMEOUT, Jibri drops… unless everyone is muted.
* If people are muted for a while, time since last media grows past NO_MEDIA_TIMEOUT and then when someone unmutes (but perhaps their media hasn’t made it to Jibri yet) we timeout instantly complaining about no media.