### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Component "internal.auth.yourdomain.com" "muc"
     modules_enabled = {
       "ping";
     }
-    storage = "null"
+    storage = "memory"
     muc_room_cache_size = 1000
 ```
 


### PR DESCRIPTION
change storage from null to memory, otherwise it gives error:
`Aug 05 11:45:57 internal.auth.domain:muc  error   Error restoring room jvbbrewery@internal.auth.domain from storage: no data storage active`