### PR TITLE
Support non-YouTube RTMP URLs

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -30,6 +30,7 @@ import org.jitsi.jibri.service.JibriServiceStatusHandler
 import org.jitsi.jibri.service.ServiceParams
 import org.jitsi.jibri.service.impl.SipGatewayServiceParams
 import org.jitsi.jibri.service.impl.StreamingParams
+import org.jitsi.jibri.service.impl.YOUTUBE_URL
 import org.jitsi.jibri.sipgateway.SipClientParams
 import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.status.JibriStatus
@@ -298,14 +299,29 @@ class XmppApi(
                 )
             }
             JibriMode.STREAM -> {
+                val rtmpUrl = if (startIq.streamId.startsWith("rtmp://", ignoreCase = true)) {
+                    startIq.streamId
+                } else {
+                    "$YOUTUBE_URL/${startIq.streamId}"
+                }
+                val viewingUrl = if (startIq.youtubeBroadcastId != null) {
+                    if (startIq.youtubeBroadcastId.startsWith("http", ignoreCase = true)) {
+                        startIq.youtubeBroadcastId
+                    } else {
+                        "http://youtu.be/${startIq.youtubeBroadcastId}"
+                    }
+                } else {
+                    null
+                }
                 jibriManager.startStreaming(
                     serviceParams,
                     StreamingParams(
                         callParams,
                         startIq.sessionId,
                         xmppEnvironment.callLogin,
-                        youTubeStreamKey = startIq.streamId,
-                        youTubeBroadcastId = startIq.youtubeBroadcastId),
+                        rtmpUrl = rtmpUrl,
+                        viewingUrl = viewingUrl
+                    ),
                     EnvironmentContext(xmppEnvironment.name),
                     serviceStatusHandler
                 )

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -313,6 +313,7 @@ class XmppApi(
                 } else {
                     null
                 }
+                logger.info("Using RTMP URL $rtmpUrl and viewing URL $viewingUrl")
                 jibriManager.startStreaming(
                     serviceParams,
                     StreamingParams(

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -299,13 +299,13 @@ class XmppApi(
                 )
             }
             JibriMode.STREAM -> {
-                val rtmpUrl = if (startIq.streamId.startsWith("rtmp://", ignoreCase = true)) {
+                val rtmpUrl = if (startIq.streamId.isRtmpUrl()) {
                     startIq.streamId
                 } else {
                     "$YOUTUBE_URL/${startIq.streamId}"
                 }
                 val viewingUrl = if (startIq.youtubeBroadcastId != null) {
-                    if (startIq.youtubeBroadcastId.startsWith("http", ignoreCase = true)) {
+                    if (startIq.youtubeBroadcastId.isViewingUrl()) {
                         startIq.youtubeBroadcastId
                     } else {
                         "http://youtu.be/${startIq.youtubeBroadcastId}"
@@ -344,3 +344,7 @@ class XmppApi(
         }
     }
 }
+
+private fun String.isRtmpUrl(): Boolean = startsWith("rtmp://", ignoreCase = true)
+private fun String.isViewingUrl(): Boolean =
+    startsWith("http://", ignoreCase = true) || startsWith("https://", ignoreCase = true)

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StatefulJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StatefulJibriService.kt
@@ -32,7 +32,7 @@ abstract class StatefulJibriService(private val name: String) : JibriService() {
     protected val logger = Logger.getLogger(this::class.qualifiedName)
 
     init {
-        stateMachine.onStateTransition(this::onServiceStateChange)
+        stateMachine.onStateTransition { oldState, newState -> this.onServiceStateChange(oldState, newState) }
     }
 
     private fun onServiceStateChange(oldState: ComponentState, newState: ComponentState) {

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -31,7 +31,7 @@ import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.util.extensions.error
 import org.jitsi.jibri.util.whenever
 
-private const val YOUTUBE_URL = "rtmp://a.rtmp.youtube.com/live2"
+const val YOUTUBE_URL = "rtmp://a.rtmp.youtube.com/live2"
 private const val STREAMING_MAX_BITRATE = 2976
 
 /**
@@ -52,13 +52,13 @@ data class StreamingParams(
      */
     val callLoginParams: XmppCredentials,
     /**
-     * The YouTube stream key to use for this stream
+     * The RTMP URL we'll stream to
      */
-    val youTubeStreamKey: String,
+    val rtmpUrl: String,
     /**
-     * The YouTube broadcast ID for this stream, if we have it
+     * The URL at which the stream can be viewed
      */
-    val youTubeBroadcastId: String? = null
+    val viewingUrl: String? = null
 )
 
 /**
@@ -75,7 +75,7 @@ class StreamingJibriService(
 
     init {
         sink = StreamSink(
-            url = "$YOUTUBE_URL/${streamingParams.youTubeStreamKey}",
+            url = streamingParams.rtmpUrl,
             streamingMaxBitrate = STREAMING_MAX_BITRATE,
             streamingBufSize = 2 * STREAMING_MAX_BITRATE
         )
@@ -94,8 +94,8 @@ class StreamingJibriService(
             try {
                 jibriSelenium.addToPresence("session_id", streamingParams.sessionId)
                 jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.STREAM.toString())
-                streamingParams.youTubeBroadcastId?.let {
-                    if (!jibriSelenium.addToPresence("live-stream-view-url", "http://youtu.be/$it")) {
+                streamingParams.viewingUrl?.let { viewingUrl ->
+                    if (!jibriSelenium.addToPresence("live-stream-view-url", viewingUrl)) {
                         logger.error("Error adding live stream url to presence")
                     }
                 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,6 +22,15 @@ jibri {
     # TODO: make this an optional param and remove the default
     finalize-script = "/path/to/finalize"
   }
+  streaming {
+    // A list of regex patterns for allowed RTMP URLs.  The RTMP URL used
+    // when starting a stream must match at least one of the patterns in
+    // this list.
+    rtmp-allow-list = [
+      // By default, all services are allowed
+      ".*"
+    ]
+  }
   chrome {
     // The flags which will be passed to chromium when launching
     flags = [


### PR DESCRIPTION
This PR introduces a method for supporting non-YouTube RTMP URLs in Jibri.  This is implemented by overloading the existing fields ([streamid](https://github.com/jitsi/jitsi-xmpp-extensions/blob/813e4c453bd3d965ad1b9901bf94f00d3af1badc/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java#L250) and [you_tube_broadcast_id](https://github.com/jitsi/jitsi-xmpp-extensions/blob/813e4c453bd3d965ad1b9901bf94f00d3af1badc/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java#L260)) in the following way:

1. If the `streamid` field starts with `rtmp://`, then we treat it as a pre-formed RTMP URL and use it to stream to directly.  Otherwise we assume it's a YouTube stream ID, as before, and create a YouTube RTMP URL from it.

2. If `you_tube_broadcast_id` is set and starts with `http`, then we treat it as a pref-formed _viewing_ URL (a URL at which people can view this stream).  If it is set and doesn't start with `http`, we assume it's a YouTube broadcast ID, as before, and construct a YouTube viewing URL from it.  If it's not set then we do nothing with it.