### PR TITLE
fix ffmpeg not stop gracefully

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/util/ProcessWrapper.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/ProcessWrapper.kt
@@ -19,6 +19,7 @@ package org.jitsi.jibri.util
 import org.jitsi.jibri.util.extensions.error
 import org.jitsi.jibri.util.extensions.pidValue
 import java.io.InputStream
+import java.io.OutputStream
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
@@ -98,7 +99,13 @@ class ProcessWrapper(
         // because we want them to read everything available from the
         // process' inputstream. Once it's done, they'll read
         // the EOF and close things up correctly
-        runtime.exec("kill -s SIGINT ${process.pidValue}")
+
+        var output: OutputStream = process.outputStream
+
+        output.write("q\n".toByteArray())
+        output.flush()
+
+        runtime.exec("bash -c \"kill -s SIGINT ${process.pidValue}\"")
     }
 
     /**


### PR DESCRIPTION
I'm deploying Jitsi using docker (latest version) and got this errors:
```
INFO: [39] org.jitsi.jibri.util.JibriSubprocess.ffmpeg.stop() Stopping ffmpeg process
SEVERE: [39] org.jitsi.jibri.util.ProcessWrapper.stopAndWaitFor() Error stopping process: java.io.IOException: Cannot run program "kill": error=2, No such file or directory with stack: 
java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
java.lang.Runtime.exec(Runtime.java:621)
java.lang.Runtime.exec(Runtime.java:451)
java.lang.Runtime.exec(Runtime.java:348)
org.jitsi.jibri.util.ProcessWrapper.stop(ProcessWrapper.kt:101)
org.jitsi.jibri.util.ProcessWrapper.stopAndWaitFor(ProcessWrapper.kt:112)
org.jitsi.jibri.util.JibriSubprocess.stop(JibriSubprocess.kt:77)
org.jitsi.jibri.capture.ffmpeg.FfmpegCapturer.stop(FfmpegCapturer.kt:125)
org.jitsi.jibri.service.impl.FileRecordingJibriService.stop(FileRecordingJibriService.kt:166)
org.jitsi.jibri.JibriManager.stopService(JibriManager.kt:262)
org.jitsi.jibri.api.xmpp.XmppApi.handleStopJibriIq(XmppApi.kt:263)
org.jitsi.jibri.api.xmpp.XmppApi.handleJibriIq(XmppApi.kt:169)
org.jitsi.jibri.api.xmpp.XmppApi.handleIq(XmppApi.kt:150)
org.jitsi.xmpp.mucclient.MucClient.handleIq(MucClient.java:569)
org.jitsi.xmpp.mucclient.MucClient.access$800(MucClient.java:50)
org.jitsi.xmpp.mucclient.MucClient$2.handleIQRequest(MucClient.java:533)
org.jivesoftware.smack.AbstractXMPPConnection$4.run(AbstractXMPPConnection.java:1188)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
java.lang.Thread.run(Thread.java:748)

SEVERE: [39] org.jitsi.jibri.util.JibriSubprocess.ffmpeg.stop() Error trying to gracefully stop ffmpeg, destroying forcibly
INFO: [39] org.jitsi.jibri.util.JibriSubprocess.ffmpeg.stop() ffmpeg exited with value 137
```
The recorded files are corrupted.

Here is how I fixed it to make it works!