### PR TITLE
Make XMPP server c2s port configurable

### DIFF
--- a/doc/example_xmpp_envs.conf
+++ b/doc/example_xmpp_envs.conf
@@ -22,7 +22,8 @@
             // The login information for the control MUC
             control-login {
                 domain = "domain"
-                port = "port"
+                // Optional port, defaults to 5222.
+                port = 6222
                 username = "username"
                 password = "password"
             }

--- a/doc/example_xmpp_envs.conf
+++ b/doc/example_xmpp_envs.conf
@@ -22,6 +22,7 @@
             // The login information for the control MUC
             control-login {
                 domain = "domain"
+                port = "port"
                 username = "username"
                 password = "password"
             }

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -103,10 +103,7 @@ class XmppApi(
                     domain = config.controlLogin.domain
                     username = config.controlLogin.username
                     password = config.controlLogin.password
-                    port = config.controlLogin.port
-
-                    if (port.isNullOrEmpty())
-                        port = "5222"
+                    config.controlLogin.port?.let { port = it.toString() }
 
                     if (config.trustAllXmppCerts) {
                         logger.info("The trustAllXmppCerts config is enabled for this domain, " +

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -103,6 +103,10 @@ class XmppApi(
                     domain = config.controlLogin.domain
                     username = config.controlLogin.username
                     password = config.controlLogin.password
+                    port = config.controlLogin.port
+
+                    if (port.isNullOrEmpty())
+                        port = "5222"
 
                     if (config.trustAllXmppCerts) {
                         logger.info("The trustAllXmppCerts config is enabled for this domain, " +

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -30,6 +30,7 @@ import java.io.File
 
 data class XmppCredentials(
     val domain: String = "",
+    val port: String = "",
     val username: String = "",
     val password: String = ""
 )
@@ -37,6 +38,7 @@ data class XmppCredentials(
 fun com.typesafe.config.Config.toXmppCredentials(): XmppCredentials =
     XmppCredentials(
         domain = getString("domain"),
+        port = getString("port"),
         username = getString("username"),
         password = getString("password")
     )

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -30,7 +30,7 @@ import java.io.File
 
 data class XmppCredentials(
     val domain: String = "",
-    val port: String = "",
+    val port: Int? = null,
     val username: String = "",
     val password: String = ""
 )
@@ -38,7 +38,7 @@ data class XmppCredentials(
 fun com.typesafe.config.Config.toXmppCredentials(): XmppCredentials =
     XmppCredentials(
         domain = getString("domain"),
-        port = getString("port"),
+        port = if (hasPath("port")) getInt("port") else null,
         username = getString("username"),
         password = getString("password")
     )
@@ -118,7 +118,7 @@ data class XmppEnvironmentConfig(
     val trustAllXmppCerts: Boolean = true
 )
 
-public fun com.typesafe.config.Config.toXmppEnvironment(): XmppEnvironmentConfig =
+fun com.typesafe.config.Config.toXmppEnvironment(): XmppEnvironmentConfig =
     XmppEnvironmentConfig(
         name = getString("name"),
         xmppServerHosts = getStringList("xmpp-server-hosts"),


### PR DESCRIPTION
Sometimes XMPP c2s port is configured to use a port other than 5222.
For example, I have two XMPP services in my server, one uses 5222 and the other uses 6222.
Jibri always uses port 5222 to connect to XMPP server, therefore, Jibri can't be connected to the second XMPP service which uses port 6222.
In the PR, the port is configured via json config file. 