### PR TITLE
Add missing dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9)
 
 Package: jibri
 Architecture: all
-Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-input-void, xserver-xorg-video-dummy
+Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-input-void, xserver-xorg-video-dummy, procps
 Description: Jibri
  Jibri can be used to capture data from a Jitsi Meet conference and record it to a file or stream it to a url


### PR DESCRIPTION
`kill` is used to gracefully stop ffmpeg, but it might be missing unless
the `procps` package is installed.

Annoyingly, bash does provide a `kill` builtin, so the bug may only
manifest in some shells.