### PR TITLE
Specify PJSUA as default video input device for sipgw

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -92,7 +92,8 @@ val SIP_GW_URL_OPTIONS = listOf(
     "config.analytics.disabled=true",
     "config.p2p.enabled=false",
     "config.prejoinPageEnabled=false",
-    "config.requireDisplayName=false"
+    "config.requireDisplayName=false",
+    "devices.videoInput=\"PJSUA\""
 )
 
 val RECORDING_URL_OPTIONS = listOf(


### PR DESCRIPTION
The order of devices is not consistent, so remove any ambiguity by being
explicit.