### PR TITLE
Update http api /health endpoint documentation

### DIFF
--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -15,7 +15,13 @@ Code: `200`
 Body:
 ```
 {
-    "busy": Boolean // true if Jibri is currently busy, false otherwise
+  "status":{
+    "busyStatus": String // "IDLE", "BUSY" or "EXPIRED"
+    "health":{
+      "healthStatus": String // "HEALTHY" or "UNHEALTHY"
+      "details": Map<String,HealthStatus> // Hash of component -> healthStatus above - only valid is "JibriManager" at present.
+    }
+  }
 }
 ```
 This call should always respond with a `200` and the status encoded in the response body.  The lack of any response would represent an error of some sort


### PR DESCRIPTION
Having written a cheap bit of `curl | jq` to parse the output of the health api, I realised the output doesn't match the docs.

Definitely needs a maintainer to confirm my assumption about the contents of the `details` map, but the below is my best effort based on:

* https://github.com/jitsi/jibri/tree/master/src/main/kotlin/org/jitsi/jibri/status
* https://github.com/jitsi/jibri/blob/master/src/main/kotlin/org/jitsi/jibri/health/JibriHealth.kt
* https://github.com/jitsi/jibri/blob/master/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt#L84

Fixes #366
