### PR TITLE
fix: missing ffmpeg pid on openjdk-11

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/util/extensions/Process.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/extensions/Process.kt
@@ -25,7 +25,8 @@ val Process.pidValue: Long
     get() {
         var pid: Long = -1
         try {
-            if (javaClass.name == "java.lang.UNIXProcess") {
+            if (javaClass.name == "java.lang.UNIXProcess" ||
+                javaClass.name == "java.lang.ProcessImpl") {
                 val field: Field = javaClass.getDeclaredField("pid")
                 field.isAccessible = true
                 pid = field.getLong(this)


### PR DESCRIPTION
`jibri` cannot get the `ffmpeg` pid when `openjdk-11` is the default. As a result, `ffmpeg` cannot be killed correctly and this will corrupt the recorded MP4 file. As a symptom "_moov atom not found_" message when checking the corrupted MP4 file with `ffmpeg -i filename.mp4`

This commit fixes this issue and `jibri` becomes compatible with `openjdk-11` which is default on Debian 10 Buster.

The root cause is: `javaClass.name` returns "_java.lang.ProcessImpl_" on openjdk-11 and it isn't match with "_java.lang.UNIXProcess_". Therefore `get()` allways returns `-1` 