### PR TITLE
Better fix for Process.pidValue jdk11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,6 @@
         <selenium.version>3.12.0</selenium.version>
         <kotlin.version>1.3.71</kotlin.version>
         <exec.mainClass>org.jitsi.jibri.MainKt</exec.mainClass>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <smack.version>4.2.4-47d17fc</smack.version>
         <jersey.version>2.30.1</jersey.version>
         <jackson.version>2.9.5</jackson.version>
@@ -24,6 +21,33 @@
         <ktor.version>1.3.1</ktor.version>
         <jicoco.version>1.1-54-g5387346</jicoco.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>target-jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+                <kcond>jdk8</kcond>
+            </properties>
+        </profile>
+        <profile>
+            <id>target-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>9</maven.compiler.source>
+                <maven.compiler.target>9</maven.compiler.target>
+                <kotlin.compiler.jvmTarget>9</kotlin.compiler.jvmTarget>
+                <kcond>jdk9</kcond>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -212,6 +236,7 @@
                         <configuration>
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/kotlin-${kcond}</sourceDir>
                                 <sourceDir>${project.basedir}/src/main/java</sourceDir>
                             </sourceDirs>
                             <args>

--- a/src/main/kotlin-jdk8/org/jitsi/jibri/util/extensions/Process.kt
+++ b/src/main/kotlin-jdk8/org/jitsi/jibri/util/extensions/Process.kt
@@ -25,7 +25,8 @@ val Process.pidValue: Long
     get() {
         var pid: Long = -1
         try {
-            if (javaClass.name == "java.lang.UNIXProcess") {
+            if (javaClass.name == "java.lang.UNIXProcess" ||
+                javaClass.name == "java.lang.ProcessImpl") {
                 val field: Field = javaClass.getDeclaredField("pid")
                 field.isAccessible = true
                 pid = field.getLong(this)

--- a/src/main/kotlin-jdk8/org/jitsi/jibri/util/extensions/Process.kt
+++ b/src/main/kotlin-jdk8/org/jitsi/jibri/util/extensions/Process.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.util.extensions
+
+import java.lang.reflect.Field
+
+/**
+ * Mimic the "pid" member of Java 9's [Process].
+ */
+val Process.pidValue: Long
+    get() {
+        var pid: Long = -1
+        try {
+            if (javaClass.name == "java.lang.UNIXProcess") {
+                val field: Field = javaClass.getDeclaredField("pid")
+                field.isAccessible = true
+                pid = field.getLong(this)
+                field.isAccessible = false
+            }
+        } catch (e: Exception) {
+            pid = -1
+        }
+        return pid
+    }

--- a/src/main/kotlin-jdk9/org/jitsi/jibri/util/extensions/Process.kt
+++ b/src/main/kotlin-jdk9/org/jitsi/jibri/util/extensions/Process.kt
@@ -16,24 +16,10 @@
 
 package org.jitsi.jibri.util.extensions
 
-import java.lang.reflect.Field
-
 /**
  * Mimic the "pid" member of Java 9's [Process].
  */
 val Process.pidValue: Long
     get() {
-        var pid: Long = -1
-        try {
-            if (javaClass.name == "java.lang.UNIXProcess" ||
-                javaClass.name == "java.lang.ProcessImpl") {
-                val field: Field = javaClass.getDeclaredField("pid")
-                field.isAccessible = true
-                pid = field.getLong(this)
-                field.isAccessible = false
-            }
-        } catch (e: Exception) {
-            pid = -1
-        }
-        return pid
+        return this.pid()
     }

--- a/src/test/kotlin/org/jitsi/jibri/util/ProcessPidValueTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/ProcessPidValueTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.jitsi.jibri.util
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import org.jitsi.jibri.util.extensions.pidValue
+
+internal class ProcessPidValueTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    init {
+        context("Check pid of child process") {
+            should("verify that pid of child process is correct") {
+                var process = ProcessBuilder("sh", "-c", "echo $$; sleep 1")
+                    .redirectErrorStream(true).start()
+                val pidFromPidValue = "${process.pidValue}"
+                val pidFromStdout = BufferedReader(InputStreamReader(process.inputStream)).readLine()
+                pidFromPidValue shouldBe pidFromStdout
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This PR was inspired by #369 which solves the problem in a sketchy manner:
When attempting to access private fields in java11, a big fat warning is printed which shows, that this is probably a bad idea:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jitsi.jibri.util.extensions.ProcessKt (file:path-of-jar-with-dependencies.jar) to field java.lang.ProcessImpl.pid
WARNING: Please consider reporting this to the maintainers of org.jitsi.jibri.util.extensions.ProcessKt
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
The proper way to solve the problem ist to refrain from using reflection with newer java versions and instead use conditional compilation to provide a different implementation. Since kotlin does not provide conditional compilation, this PR uses two maven profiles to define different source directories depending on the JDK version used during build.
- With JDK8, the old implementation located below src/main/kotlin-jdk8 is compiled and targets ar set to 1.8
- With JDK>8, the new implementation located below src/main/kotlin-jdk9 is compiled and targets are set to 9

Finally, this PR also adds a small UT for testing the correctness of Process.pidValue

Cheers
 -Fritz

PS: CLA already signed, do you need some proof of that?