### PR TITLE
A few test fixes, upgrade kotest to 4.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <jersey.version>2.30.1</jersey.version>
         <jackson.version>2.9.5</jackson.version>
         <junit.version>5.2.0</junit.version>
-        <kotest.version>4.1.3</kotest.version>
+        <kotest.version>4.3.2</kotest.version>
         <mockk.version>1.10.0</mockk.version>
         <ktor.version>1.3.1</ktor.version>
         <jicoco.version>1.1-54-g5387346</jicoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-extensions-junitxml-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom2</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
             <version>${mockk.version}</version>
@@ -262,6 +274,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- gradle.build.dir is the property name that JunitXmlReporter expects to find, even though
+                        this is maven -->
+                        <gradle.build.dir>${project.build.directory}/surefire-reports</gradle.build.dir>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-mvn clean verify package
+mvn -B clean verify package

--- a/src/test/kotlin/org/jitsi/jibri/KotestProjectConfig.kt
+++ b/src/test/kotlin/org/jitsi/jibri/KotestProjectConfig.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.listeners.Listener
+import io.kotest.extensions.junitxml.JunitXmlReporter
+
+class KotestProjectConfig : AbstractProjectConfig() {
+    override fun listeners(): List<Listener> = listOf(
+        /**
+         * The JunitXmlReporter writes a junit5 compatible unit test output
+         * but with the full scope of tests as their name, unlike the default
+         * one which only includes the 'should' block from kotest tests as
+         * the name.  See https://kotest.io/docs/extensions/junit_xml.html.
+         */
+        JunitXmlReporter(
+            includeContainers = false,
+            useTestPathAsName = true,
+            outputDir = "full-test-name-test-results"
+        )
+    )
+}

--- a/src/test/kotlin/org/jitsi/jibri/api/http/HttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/HttpApiTest.kt
@@ -22,7 +22,7 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.core.spec.style.scopes.ShouldSpecContextScope
 import io.kotest.core.test.TestContext
-import io.kotest.core.test.TestName
+import io.kotest.core.test.createTestName
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -55,7 +55,7 @@ import org.jitsi.jibri.status.JibriStatusManager
 import org.jitsi.jibri.status.OverallHealth
 
 class HttpApiTest : ShouldSpec() {
-    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
 
     private val jibriManager: JibriManager = mockk()
     private val jibriStatusManager: JibriStatusManager = mockk()
@@ -66,7 +66,7 @@ class HttpApiTest : ShouldSpec() {
         context("health") {
             context("when jibri isn't busy") {
                 val expectedStatus =
-                        JibriStatus(ComponentBusyStatus.IDLE, OverallHealth(ComponentHealthStatus.HEALTHY, mapOf()))
+                    JibriStatus(ComponentBusyStatus.IDLE, OverallHealth(ComponentHealthStatus.HEALTHY, mapOf()))
                 val expectedHealth = JibriHealth(expectedStatus)
 
                 every { jibriManager.currentEnvironmentContext } returns null
@@ -169,4 +169,4 @@ class HttpApiTest : ShouldSpec() {
  * scope
  */
 fun ShouldSpecContextScope.shouldb(name: String, test: suspend TestContext.() -> Unit) =
-    runBlocking { addTest(TestName("should ", name), xdisabled = false, test = test) }
+    runBlocking { addTest(createTestName("should ", name, true), xdisabled = false, test = test) }

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -20,7 +20,7 @@ package org.jitsi.jibri.api.xmpp
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
-import io.kotest.matchers.beInstanceOf
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -146,7 +146,7 @@ class XmppApiTest : ShouldSpec() {
                     val response = xmppApi.handleIq(jibriIq, mucClient)
                     should("send a pending response to the original IQ request") {
                         response shouldNotBe null
-                        response should beInstanceOf<JibriIq>()
+                        response should beInstanceOf(JibriIq::class)
                         response as JibriIq
                         response.status shouldBe JibriIq.Status.PENDING
                     }
@@ -156,9 +156,10 @@ class XmppApiTest : ShouldSpec() {
                             val sentStanzas = mutableListOf<Stanza>()
                             verify { mucClient.sendStanza(capture(sentStanzas)) }
                             sentStanzas.size shouldBe 1
-                            sentStanzas.first().shouldBeInstanceOf<JibriIq> {
-                                it.status shouldBe JibriIq.Status.ON
-                            }
+                            val stanza = sentStanzas.first()
+                            stanza should beInstanceOf<JibriIq>()
+                            stanza as JibriIq
+                            stanza.status shouldBe JibriIq.Status.ON
                         }
                         context("and it is stopped") {
 //                            whenever(jibriManager.stopService()) doAnswer {}
@@ -167,9 +168,9 @@ class XmppApiTest : ShouldSpec() {
                             should("respond correctly") {
                                 verify { jibriManager.stopService() }
                                 stopResponse shouldBeResponseTo stopIq
-                                stopResponse.shouldBeInstanceOf<JibriIq> {
-                                    it.status shouldBe JibriIq.Status.OFF
-                                }
+                                stopResponse.shouldBeInstanceOf<JibriIq>()
+                                stopResponse as JibriIq
+                                stopResponse.status shouldBe JibriIq.Status.OFF
                             }
                         }
                     }
@@ -178,11 +179,11 @@ class XmppApiTest : ShouldSpec() {
                     every { jibriManager.startFileRecording(any(), any(), any(), any()) } throws JibriBusyException()
                     should("send an error IQ") {
                         val response = xmppApi.handleIq(jibriIq, mucClient)
-                        response.shouldBeInstanceOf<JibriIq> {
-                            it.status shouldBe JibriIq.Status.OFF
-                            it.failureReason shouldBe JibriIq.FailureReason.BUSY
-                            it.shouldRetry shouldBe true
-                        }
+                        response should beInstanceOf<JibriIq>()
+                        response as JibriIq
+                        response.status shouldBe JibriIq.Status.OFF
+                        response.failureReason shouldBe JibriIq.FailureReason.BUSY
+                        response.shouldRetry shouldBe true
                     }
                 }
                 context("with application data") {

--- a/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.collections.contain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.Runs
 import io.mockk.every
@@ -109,7 +110,7 @@ internal class FfmpegCapturerTest : ShouldSpec() {
                         context("capture") {
                             should("report its stats as error") {
                                 val error = capturerStateUpdates.last()
-                                error.shouldBeInstanceOf<ComponentState.Error>()
+                                error should beInstanceOf<ComponentState.Error>()
                                 error as ComponentState.Error
                                 error.error.scope shouldBe ErrorScope.SESSION
                             }
@@ -120,7 +121,7 @@ internal class FfmpegCapturerTest : ShouldSpec() {
                         context("capture") {
                             should("report its stats as error") {
                                 val error = capturerStateUpdates.last()
-                                error.shouldBeInstanceOf<ComponentState.Error>()
+                                error should beInstanceOf<ComponentState.Error>()
                                 error as ComponentState.Error
                                 error.error.scope shouldBe ErrorScope.SESSION
                             }
@@ -137,7 +138,7 @@ internal class FfmpegCapturerTest : ShouldSpec() {
                     should("report its status as a system error") {
                         capturerStateUpdates.shouldNotBeEmpty()
                         val status = capturerStateUpdates.last()
-                        status.shouldBeInstanceOf<ComponentState.Error>()
+                        status should beInstanceOf<ComponentState.Error>()
                         status as ComponentState.Error
                         status.error.scope shouldBe ErrorScope.SYSTEM
                     }

--- a/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/OutputParserTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/executor/OutputParserTest.kt
@@ -19,7 +19,7 @@ package org.jitsi.jibri.capture.ffmpeg.executor
 
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
-import io.kotest.matchers.beInstanceOf
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import org.jitsi.jibri.status.ErrorScope

--- a/src/test/kotlin/org/jitsi/jibri/selenium/SeleniumStateMachineTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/SeleniumStateMachineTest.kt
@@ -19,7 +19,7 @@ package org.jitsi.jibri.selenium
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
-import io.kotest.matchers.beInstanceOf
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/org/jitsi/jibri/util/JibriSubprocessTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/JibriSubprocessTest.kt
@@ -32,7 +32,7 @@ import org.jitsi.jibri.helpers.resetOutputLogger
 import org.jitsi.jibri.helpers.setTestOutputLogger
 
 internal class JibriSubprocessTest : ShouldSpec() {
-    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
 
     private val processFactory: ProcessFactory = mockk()
     private val processWrapper: ProcessWrapper = mockk(relaxed = true)
@@ -44,7 +44,12 @@ internal class JibriSubprocessTest : ShouldSpec() {
 
     init {
         beforeSpec {
-            LoggingUtils.setTestOutputLogger { _, _ -> mockk(relaxed = true) }
+            LoggingUtils.setTestOutputLogger { _, _ ->
+                mockk {
+                    every { get() } returns true
+                    every { get(any(), any()) } returns true
+                }
+            }
 
             every { processFactory.createProcess(any(), any(), any()) } returns processWrapper
             every { processStatePublisher.addStatusHandler(capture(processStateHandler)) } just Runs

--- a/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
@@ -20,10 +20,11 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.beInstanceOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockEngineConfig
@@ -99,13 +100,15 @@ class WebhookClientTest : ShouldSpec({
                 should("send the correct data") {
                     within(Duration.ofMillis(2000)) {
                         requests[0].body.contentType shouldBe ContentType.Application.Json
-                        requests[0].body.shouldBeInstanceOf<TextContent> {
-                            it.text shouldBe jacksonObjectMapper().writeValueAsString(
+                        with(requests[0].body) {
+                            this should beInstanceOf<TextContent>()
+                            this as TextContent
+                            this.text shouldBe jacksonObjectMapper().writeValueAsString(
                                 JibriEvent.HealthEvent("test", goodStatus)
                             )
-                            it.text shouldContain """
-                            "jibriId":"test"
-                        """.trimIndent()
+                            text shouldContain """
+                                "jibriId":"test"
+                            """.trimIndent()
                         }
                     }
                 }
@@ -114,8 +117,10 @@ class WebhookClientTest : ShouldSpec({
                     should("send another request with the new status") {
                         within(Duration.ofMillis(2000)) {
                             requests shouldHaveSize 2
-                            requests[1].body.shouldBeInstanceOf<TextContent> {
-                                it.text shouldContain jacksonObjectMapper().writeValueAsString(
+                            with(requests[1].body) {
+                                this should beInstanceOf<TextContent>()
+                                this as TextContent
+                                this.text shouldContain jacksonObjectMapper().writeValueAsString(
                                     JibriEvent.HealthEvent("test", badStatus)
                                 )
                             }


### PR DESCRIPTION
While starting to look into a flaky unit test I found some other test issues, so wanted to address those first.  These changes fix a couple minor things, upgrade kotest to 4.3.2 and add a junit xml reporter which uses the full tree of kotest scopes as the test name to help reduce ambiguity when a test fails.