### PR TITLE
Webhook test fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
 
         <!-- testing -->
         <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jicoco-test-kotlin</artifactId>
+            <version>1.1-79-g6099be5</version>
+        </dependency>
+        <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-runner-junit5-jvm</artifactId>
             <version>${kotest.version}</version>

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -20,11 +20,10 @@ package org.jitsi.jibri.api.xmpp
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
-import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.beInstanceOf
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -32,7 +31,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.jitsi.jibri.JibriBusyException
-import org.jitsi.xmpp.extensions.jibri.JibriIq
 import org.jitsi.jibri.JibriManager
 import org.jitsi.jibri.config.XmppCredentials
 import org.jitsi.jibri.config.XmppEnvironmentConfig
@@ -42,13 +40,14 @@ import org.jitsi.jibri.helpers.setIoPool
 import org.jitsi.jibri.service.AppData
 import org.jitsi.jibri.service.JibriServiceStatusHandler
 import org.jitsi.jibri.service.ServiceParams
-import org.jitsi.jibri.status.ComponentState
-import org.jitsi.jibri.status.ComponentHealthStatus
 import org.jitsi.jibri.status.ComponentBusyStatus
-import org.jitsi.jibri.status.JibriStatusManager
+import org.jitsi.jibri.status.ComponentHealthStatus
+import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.status.JibriStatus
+import org.jitsi.jibri.status.JibriStatusManager
 import org.jitsi.jibri.status.OverallHealth
 import org.jitsi.jibri.util.TaskPools
+import org.jitsi.xmpp.extensions.jibri.JibriIq
 import org.jitsi.xmpp.mucclient.MucClient
 import org.jitsi.xmpp.mucclient.MucClientManager
 import org.jivesoftware.smack.packet.IQ
@@ -168,7 +167,7 @@ class XmppApiTest : ShouldSpec() {
                             should("respond correctly") {
                                 verify { jibriManager.stopService() }
                                 stopResponse shouldBeResponseTo stopIq
-                                stopResponse.shouldBeInstanceOf<JibriIq>()
+                                stopResponse should beInstanceOf<JibriIq>()
                                 stopResponse as JibriIq
                                 stopResponse.status shouldBe JibriIq.Status.OFF
                             }

--- a/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
@@ -61,28 +61,31 @@ class WebhookClientTest : ShouldSpec({
             mapOf()
         )
     )
-    val client = WebhookClient("test", client = HttpClient(MockEngine) {
-        engine {
-            addHandler { request ->
-                requests += request
-                with(request.url.toString()) {
-                    when {
-                        contains("success") -> {
-                            respondOk()
+    val client = WebhookClient(
+        "test",
+        client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    requests += request
+                    with(request.url.toString()) {
+                        when {
+                            contains("success") -> {
+                                respondOk()
+                            }
+                            contains("delay") -> {
+                                delay(1000)
+                                respondOk()
+                            }
+                            contains("error") -> {
+                                respondError(HttpStatusCode.BadRequest)
+                            }
+                            else -> error("Unsupported URL")
                         }
-                        contains("delay") -> {
-                            delay(1000)
-                            respondOk()
-                        }
-                        contains("error") -> {
-                            respondError(HttpStatusCode.BadRequest)
-                        }
-                        else -> error("Unsupported URL")
                     }
                 }
             }
         }
-    })
+    )
     context("when the client") {
         context("has a valid subscriber") {
             client.addSubscriber("success")

--- a/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClientTest.kt
@@ -36,16 +36,20 @@ import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.mockk.every
+import io.mockk.slot
+import io.mockk.spyk
 import kotlinx.coroutines.delay
-import org.jitsi.jibri.helpers.within
 import org.jitsi.jibri.status.ComponentBusyStatus
 import org.jitsi.jibri.status.ComponentHealthStatus
 import org.jitsi.jibri.status.JibriStatus
 import org.jitsi.jibri.status.OverallHealth
-import java.time.Duration
+import org.jitsi.jibri.util.TaskPools
+import org.jitsi.test.concurrent.FakeExecutorService
 
 class WebhookClientTest : ShouldSpec({
     isolationMode = IsolationMode.InstancePerLeaf
+
     val requests = mutableListOf<HttpRequestData>()
     val goodStatus = JibriStatus(
         ComponentBusyStatus.IDLE,
@@ -86,47 +90,61 @@ class WebhookClientTest : ShouldSpec({
             }
         }
     )
+
+    // Coroutines will sometimes try to execute a launch in the calling thread, so the normal FakeExecutorService
+    // doesn't work as it relies on the calling code finishing and then the test code being able to call runOne
+    // or runAll, etc.  This overrides the execute method (which is what gets used by coroutine dispatchers) and
+    // executes the Runnable immediately.
+    val ioExecutor: FakeExecutorService = spyk {
+        val runnable = slot<Runnable>()
+        every { execute(capture(runnable)) } answers {
+            runnable.captured.run()
+        }
+    }
+
+    beforeSpec {
+        TaskPools.ioPool = ioExecutor
+    }
+
+    afterSpec {
+        TaskPools.Companion.ioPool = TaskPools.DefaultIoPool
+    }
+
     context("when the client") {
         context("has a valid subscriber") {
             client.addSubscriber("success")
             context("calling updateStatus") {
                 client.updateStatus(goodStatus)
                 should("send a POST to the subscriber at the proper url") {
-                    within(Duration.ofMillis(2000)) {
-                        requests shouldHaveSize 1
-                        with(requests[0]) {
-                            url.toString() shouldContain "/v1/status"
-                            method shouldBe HttpMethod.Post
-                        }
+                    requests shouldHaveSize 1
+                    with(requests[0]) {
+                        url.toString() shouldContain "/v1/status"
+                        method shouldBe HttpMethod.Post
                     }
                 }
                 should("send the correct data") {
-                    within(Duration.ofMillis(2000)) {
-                        requests[0].body.contentType shouldBe ContentType.Application.Json
-                        with(requests[0].body) {
-                            this should beInstanceOf<TextContent>()
-                            this as TextContent
-                            this.text shouldBe jacksonObjectMapper().writeValueAsString(
-                                JibriEvent.HealthEvent("test", goodStatus)
-                            )
-                            text shouldContain """
-                                "jibriId":"test"
-                            """.trimIndent()
-                        }
+                    requests[0].body.contentType shouldBe ContentType.Application.Json
+                    with(requests[0].body) {
+                        this should beInstanceOf<TextContent>()
+                        this as TextContent
+                        this.text shouldBe jacksonObjectMapper().writeValueAsString(
+                            JibriEvent.HealthEvent("test", goodStatus)
+                        )
+                        text shouldContain """
+                            "jibriId":"test"
+                        """.trimIndent()
                     }
                 }
                 context("and calling updateStatus again") {
                     client.updateStatus(badStatus)
                     should("send another request with the new status") {
-                        within(Duration.ofMillis(2000)) {
-                            requests shouldHaveSize 2
-                            with(requests[1].body) {
-                                this should beInstanceOf<TextContent>()
-                                this as TextContent
-                                this.text shouldContain jacksonObjectMapper().writeValueAsString(
-                                    JibriEvent.HealthEvent("test", badStatus)
-                                )
-                            }
+                        requests shouldHaveSize 2
+                        with(requests[1].body) {
+                            this should beInstanceOf<TextContent>()
+                            this as TextContent
+                            this.text shouldContain jacksonObjectMapper().writeValueAsString(
+                                JibriEvent.HealthEvent("test", badStatus)
+                            )
                         }
                     }
                 }
@@ -139,23 +157,19 @@ class WebhookClientTest : ShouldSpec({
             context("calling updateStatus") {
                 client.updateStatus(goodStatus)
                 should("send a POST to the subscribers at the proper url") {
-                    within(Duration.ofMillis(2000)) {
-                        requests shouldHaveSize 3
-                        requests shouldContainRequestTo "success"
-                        requests shouldContainRequestTo "delay"
-                        requests shouldContainRequestTo "error"
-                    }
+                    requests shouldHaveSize 3
+                    requests shouldContainRequestTo "success"
+                    requests shouldContainRequestTo "delay"
+                    requests shouldContainRequestTo "error"
                 }
                 context("and calling updateStatus again") {
                     requests.clear()
                     client.updateStatus(goodStatus)
                     should("send a POST to the subscribers at the proper url") {
-                        within(Duration.ofMillis(2000)) {
-                            requests shouldHaveSize 3
-                            requests shouldContainRequestTo "success"
-                            requests shouldContainRequestTo "delay"
-                            requests shouldContainRequestTo "error"
-                        }
+                        requests shouldHaveSize 3
+                        requests shouldContainRequestTo "success"
+                        requests shouldContainRequestTo "delay"
+                        requests shouldContainRequestTo "error"
                     }
                 }
             }


### PR DESCRIPTION
I've fought quite a bit with getting tests for coroutine code deterministic.  Eventually, `WebhookClient` should probably be refactored to take in a scope or dispatcher so we can use a built-in test coroutine dispatcher, but in the meantime I _think_ this should be working better by using a fake executor to execute tasks immediately.