### PR TITLE
make the passing of the legacy config file command line arg optional

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -172,7 +172,7 @@ private fun handleCommandLineArgs(args: Array<String>) {
         .defaultHelp(true)
         .description("Start Jibri")
     argParser.addArgument("-c", "--config")
-        .required(true)
+        .required(false)
         .type(String::class.java)
         .help("Path to the jibri config file")
     argParser.addArgument("--internal-http-port")
@@ -198,7 +198,9 @@ private fun handleCommandLineArgs(args: Array<String>) {
         }
     }
 
-    setupLegacyConfig(configFilePath)
+    configFilePath?.let {
+        setupLegacyConfig(it)
+    } ?: logger.info("No legacy config file set")
 }
 
 /**


### PR DESCRIPTION
Jibri still supports the old-style config (a json file) which is passed via a command-line argument.  Currently, that command-line argument is marked as required, but since that config is no longer necessary we can make it optional.