### PR TITLE
Adding XMPP Port option to config file

### DIFF
--- a/doc/example_xmpp_envs.conf
+++ b/doc/example_xmpp_envs.conf
@@ -11,6 +11,9 @@
             // The base XMPP domain
             xmpp-domain = "xmpp-domain"
 
+            // XMPP port, optional, default 5222
+            xmpp-port = "5222"
+
             // The MUC we'll join to announce our presence for
             // recording and streaming services
             control-muc {

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -111,6 +111,14 @@ class XmppApi(
                         disableCertificateVerification = config.trustAllXmppCerts
                     }
 
+                    // FLOSS PATCH, 2021-01-12
+                    if (config.xmppPort != "") {
+                        logger.info("The xmppPort config is enabled for this Jibri")
+                        port = config.xmppPort
+                    } else {
+                        port = "5222"
+                    }
+
                     val recordingMucJid =
                         JidCreate.bareFrom("${config.controlMuc.roomName}@${config.controlMuc.domain}").toString()
                     val sipMucJid: String? = config.sipControlMuc?.let {

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -70,6 +70,11 @@ data class XmppEnvironmentConfig(
     @JsonProperty("xmpp_domain")
     val xmppDomain: String,
     /**
+     * Optional port for XMPP connection, FLOSS PATCH, 2021-01-12
+     */
+    @JsonProperty("xmpp_port")
+    val xmppPort: String,
+    /**
      * The login information for the control API
      */
     @JsonProperty("control_login")
@@ -120,6 +125,8 @@ public fun com.typesafe.config.Config.toXmppEnvironment(): XmppEnvironmentConfig
         name = getString("name"),
         xmppServerHosts = getStringList("xmpp-server-hosts"),
         xmppDomain = getString("xmpp-domain"),
+        /* FLOSS PATCH, 2021-01-12 */
+        xmppPort = getString("xmpp-port"),
         controlLogin = getConfig("control-login").toXmppCredentials(),
         controlMuc = getConfig("control-muc").toXmppMuc(),
         sipControlMuc = if (hasPath("sip-control-muc")) {

--- a/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/xmpp/XmppApiTest.kt
@@ -80,6 +80,8 @@ class XmppApiTest : ShouldSpec() {
             name = "xmppEnvName",
             xmppServerHosts = listOf("xmppServerHost1", "xmppServerHost2"),
             xmppDomain = "xmppDomain",
+            // FLOSS PATCH, 2021-01-12
+            xmppPort = "xmppPort",
             controlLogin = XmppCredentials(
                 domain = "controlXmppDomain",
                 username = "xmppUsername",


### PR DESCRIPTION
It allows Jibri to be configured with a non-standard XMPP port.

It's handy when you have Prosody using non standard ports (behind a loadbalancer/firewall, several deployments using the same IP, etc...)