### PR TITLE
Support sending the web display name separate from the pjsua identity…

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -69,15 +69,20 @@ data class CallParams(
      * Override the default value of callStats username.
      * Note that this is currently only used in the sipgateway gateway scenario;
      */
-    val callStatsUsernameOverride: String = ""
+    val callStatsUsernameOverride: String = "",
+    /**
+     * Display name which when it is set, it is used by jibri when joining the web conference.
+     * Note that this is currently only used in the sipgateway gateway scenario;
+     */
+    val displayName: String = ""
 ) {
     override fun toString(): String {
         return if (passcode.isNullOrEmpty()) {
             "CallParams(callUrlInfo=$callUrlInfo, email='$email', passcode=$passcode" +
-                    ", callStatsUsernameOverride=$callStatsUsernameOverride)"
+                    ", callStatsUsernameOverride=$callStatsUsernameOverride, displayName=$displayName)"
         } else {
             "CallParams(callUrlInfo=$callUrlInfo, email='$email', passcode=*****" +
-                    ", callStatsUsernameOverride=$callStatsUsernameOverride)"
+                    ", callStatsUsernameOverride=$callStatsUsernameOverride, displayName=$displayName)"
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -63,7 +63,9 @@ class SipGatewayJibriService(
     private val jibriSelenium = jibriSelenium ?: JibriSelenium(
         logger,
         JibriSeleniumOptions(
-            displayName = if (sipGatewayServiceParams.sipClientParams.sipAddress.isNotBlank()) {
+            displayName = if (sipGatewayServiceParams.callParams.displayName.isNotBlank()) {
+                sipGatewayServiceParams.callParams.displayName
+            } else if (sipGatewayServiceParams.sipClientParams.sipAddress.isNotBlank()) {
                 sipGatewayServiceParams.sipClientParams.sipAddress.substringBeforeLast("@")
             } else {
                 sipGatewayServiceParams.sipClientParams.displayName
@@ -75,6 +77,7 @@ class SipGatewayJibriService(
             extraChromeCommandLineFlags = listOf("--alsa-input-device=plughw:1,1")
         )
     )
+
     /**
      * The SIP client we'll use to connect to the SIP call (currently only a
      * pjsua implementation exists)

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
@@ -26,8 +26,8 @@ data class SipClientParams(
      */
     val sipAddress: String = "",
     /**
-     * The display name we'll use for the web conference
-     * in the pjsua call
+     * The display name used by pjsua as identity when listening for or sending an invite
+     * For sending an invite, this should be the name of the entity initiating the invite
      */
     val displayName: String = "",
     /**


### PR DESCRIPTION
… name

This PR is useful especially when making an outbound call, to allow more control over what display name is used in the web conference when the callee joins the meeting, versus what identity pjsua uses when making a call (which is going the be the identity of the caller, not the callee). 