### PR TITLE
Do not rotate pjsua logs for now, as this can result in blocking the …

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -21,12 +21,10 @@ import org.jitsi.jibri.config.Config
 import org.jitsi.jibri.sipgateway.SipClient
 import org.jitsi.jibri.sipgateway.SipClientParams
 import org.jitsi.jibri.sipgateway.pjsua.util.PjsuaExitedPrematurely
-import org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler
 import org.jitsi.jibri.sipgateway.pjsua.util.RemoteSipClientBusy
 import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.util.JibriSubprocess
 import org.jitsi.jibri.util.ProcessExited
-import org.jitsi.jibri.util.getLoggerWithHandler
 import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
@@ -44,14 +42,13 @@ class PjsuaClient(
     private val pjsuaClientParams: PjsuaClientParams
 ) : SipClient() {
     private val logger = createChildLogger(parentLogger)
-    private val pjsua: JibriSubprocess = JibriSubprocess(logger, "pjsua", pjsuaOutputLogger)
+    private val pjsua: JibriSubprocess = JibriSubprocess(logger, "pjsua")
     private val sipOutboundPrefix: String? by optionalconfig(
         "jibri.sip.outbound-prefix".from(Config.configSource)
     )
 
     companion object {
         const val COMPONENT_ID = "Pjsua"
-        private val pjsuaOutputLogger = getLoggerWithHandler("pjsua", PjsuaFileHandler())
     }
 
     init {


### PR DESCRIPTION
…stdout writing of pjsua. Also this leads to the app hanging, even after closing the sip session.
Therefore for now we keep launching pjsua from a script with redirecting stdout to dev/null, and enabling log files in pjsua configs/disabling stderr.