### PR TITLE
fix: remove xserver-xorg-input-void dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo chmod 0755 /usr/local/bin/chromedriver
 ### Miscellaneous required tools
 See the debian [control file](debian/control) for the dependencies that are required.
 These can be installed using the following:
-`sudo apt-get install default-jre-headless ffmpeg curl alsa-utils icewm xdotool xserver-xorg-input-void xserver-xorg-video-dummy`
+`sudo apt-get install default-jre-headless ffmpeg curl alsa-utils icewm xdotool xserver-xorg-video-dummy`
 
 ### Jitsi Debian Repository
 The Jibri packages can be found in the stable repository on downloads.jitsi.org.

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9)
 
 Package: jibri
 Architecture: all
-Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-input-void, xserver-xorg-video-dummy, procps
+Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-video-dummy, procps
 Description: Jibri
  Jibri can be used to capture data from a Jitsi Meet conference and record it to a file or stream it to a url

--- a/resources/debian-package/etc/jitsi/jibri/xorg-video-dummy.conf
+++ b/resources/debian-package/etc/jitsi/jibri/xorg-video-dummy.conf
@@ -11,18 +11,6 @@ Section "ServerFlags"
   Option "AutoAddDevices" "false"
 EndSection
 
-Section "InputDevice"
-  Identifier "dummy_mouse"
-  Option "CorePointer" "true"
-  Driver "void"
-EndSection
-
-Section "InputDevice"
-  Identifier "dummy_keyboard"
-  Option "CoreKeyboard" "true"
-  Driver "void"
-EndSection
-
 Section "Device"
   Identifier "dummy_videocard"
   Driver "dummy"
@@ -130,6 +118,4 @@ EndSection
 Section "ServerLayout"
   Identifier   "dummy_layout"
   Screen       "dummy_screen"
-  InputDevice  "dummy_mouse"
-  InputDevice  "dummy_keyboard"
 EndSection


### PR DESCRIPTION
This PR removes the `xserver-xorg-input-void` dependency which is not needed for a long time.

See [issue #423](https://github.com/jitsi/jibri/issues/423)