### PR TITLE
fix(conf) remove no longer needed Chrome switch

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -49,7 +49,6 @@ jibri {
       "--start-maximized",
       "--kiosk",
       "--enabled",
-      "--disable-infobars",
       "--autoplay-policy=no-user-gesture-required"
     ]
   }


### PR DESCRIPTION
It was deprecated in Chrome 76:

~~~
--disable-infobars is no longer supported

Chrome will no longer support the --disable-infobars flag, which was used to hide pop-up warnings
from Chrome Browser. To support automated testing, kiosks, and automation, the
CommandLineFlagSecurityWarningsEnabled policy was added to allow you to disable some security
warnings.
~~~