### PR TITLE
fix: get the internal-api-port from jibri.conf if exists

### DIFF
--- a/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh
+++ b/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-curl -X POST http://127.0.0.1:3333/jibri/api/internal/v1.0/gracefulShutdown
+CONF="/etc/jitsi/jibri/jibri.conf"
+PORT=$(egrep -so "^\s*internal-api-port\s*=\s*[0-9]+" $CONF | \
+    egrep -so "[0-9]+" | tail -1)
+[[ -z "$PORT" ]] && PORT=3333
+
+curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/gracefulShutdown

--- a/resources/debian-package/opt/jitsi/jibri/reload.sh
+++ b/resources/debian-package/opt/jitsi/jibri/reload.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-curl -X POST http://127.0.0.1:3333/jibri/api/internal/v1.0/notifyConfigChanged
+CONF="/etc/jitsi/jibri/jibri.conf"
+PORT=$(egrep -so "^\s*internal-api-port\s*=\s*[0-9]+" $CONF | \
+    egrep -so "[0-9]+" | tail -1)
+[[ -z "$PORT" ]] && PORT=3333
+
+curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/notifyConfigChanged

--- a/resources/debian-package/opt/jitsi/jibri/shutdown.sh
+++ b/resources/debian-package/opt/jitsi/jibri/shutdown.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-curl -X POST http://127.0.0.1:3333/jibri/api/internal/v1.0/shutdown
+CONF="/etc/jitsi/jibri/jibri.conf"
+PORT=$(egrep -so "^\s*internal-api-port\s*=\s*[0-9]+" $CONF | \
+    egrep -so "[0-9]+" | tail -1)
+[[ -z "$PORT" ]] && PORT=3333
+
+curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/shutdown


### PR DESCRIPTION
[issue #444](https://github.com/jitsi/jibri/issues/444)

Allow to use the customized `internal-api-port` in `jibri` tools if `internal-api-port` is changed in `jibri.conf`