### PR TITLE
fix: get the internal-api-port from jibri.conf if exists (hocon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo chmod 0755 /usr/local/bin/chromedriver
 ### Miscellaneous required tools
 See the debian [control file](debian/control) for the dependencies that are required.
 These can be installed using the following:
-`sudo apt-get install default-jre-headless ffmpeg curl alsa-utils icewm xdotool xserver-xorg-video-dummy`
+`sudo apt-get install default-jre-headless ffmpeg curl alsa-utils icewm xdotool xserver-xorg-video-dummy ruby-hocon`
 
 ### Jitsi Debian Repository
 The Jibri packages can be found in the stable repository on downloads.jitsi.org.

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9)
 
 Package: jibri
 Architecture: all
-Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-video-dummy, procps
+Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-video-dummy, procps, ruby-hocon
 Description: Jibri
  Jibri can be used to capture data from a Jitsi Meet conference and record it to a file or stream it to a url

--- a/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh
+++ b/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-curl -X POST http://127.0.0.1:3333/jibri/api/internal/v1.0/gracefulShutdown
+CONF="/etc/jitsi/jibri/jibri.conf"
+
+PORT=$(hocon -f $CONF get jibri.api.http.internal-api-port 2>/dev/null || true)
+[[ -z "$PORT" ]] && PORT=3333
+
+curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/gracefulShutdown

--- a/resources/debian-package/opt/jitsi/jibri/reload.sh
+++ b/resources/debian-package/opt/jitsi/jibri/reload.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-curl -X POST http://127.0.0.1:3333/jibri/api/internal/v1.0/notifyConfigChanged
+CONF="/etc/jitsi/jibri/jibri.conf"
+
+PORT=$(hocon -f $CONF get jibri.api.http.internal-api-port 2>/dev/null || true)
+[[ -z "$PORT" ]] && PORT=3333
+
+curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/notifyConfigChanged

--- a/resources/debian-package/opt/jitsi/jibri/shutdown.sh
+++ b/resources/debian-package/opt/jitsi/jibri/shutdown.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-curl -X POST http://127.0.0.1:3333/jibri/api/internal/v1.0/shutdown
+CONF="/etc/jitsi/jibri/jibri.conf"
+
+PORT=$(hocon -f $CONF get jibri.api.http.internal-api-port 2>/dev/null || true)
+[[ -z "$PORT" ]] && PORT=3333
+
+curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/shutdown


### PR DESCRIPTION
[issue #444](https://github.com/jitsi/jibri/issues/444)

Allow to use the customized `internal-api-port` in `jibri` tools if `internal-api-port` is customized in `jibri.conf`.
This PR requires the `ruby-hocon` package as a `jibri` dependency.