### PR TITLE
fix: Update jetty to match jicoco.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.41.v20210516</version>
+            <version>9.4.44.v20210927</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
After bumping jicoco to the latest version in the previous commit the
health check service started misbehaving with

/usr/bin/curl --max-time 30 -f http://localhost:2222/jibri/api/v1.0/health
curl: (18) transfer closed with outstanding read data remaining