### PR TITLE
Add an ICE connection check, increae no-media-timeout

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/Errors.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/Errors.kt
@@ -22,3 +22,4 @@ import org.jitsi.jibri.status.ErrorScope
 object FailedToJoinCall : JibriError(ErrorScope.SESSION, "Failed to join the call")
 object ChromeHung : JibriError(ErrorScope.SESSION, "Chrome hung")
 object NoMediaReceived : JibriError(ErrorScope.SESSION, "No media received")
+object IceFailed : JibriError(ErrorScope.SESSION, "ICE failed")

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -23,6 +23,7 @@ import org.jitsi.jibri.config.XmppCredentials
 import org.jitsi.jibri.selenium.pageobjects.CallPage
 import org.jitsi.jibri.selenium.pageobjects.HomePage
 import org.jitsi.jibri.selenium.status_checks.EmptyCallStatusCheck
+import org.jitsi.jibri.selenium.status_checks.IceConnectionStatusCheck
 import org.jitsi.jibri.selenium.status_checks.LocalParticipantKickedStatusCheck
 import org.jitsi.jibri.selenium.status_checks.MediaReceivedStatusCheck
 import org.jitsi.jibri.selenium.util.BrowserFileHandler
@@ -223,6 +224,7 @@ class JibriSelenium(
         val callStatusChecks = buildList {
             add(EmptyCallStatusCheck(logger, callEmptyTimeout = jibriSeleniumOptions.emptyCallTimeout))
             add(MediaReceivedStatusCheck(logger))
+            add(IceConnectionStatusCheck(logger))
             if (jibriSeleniumOptions.enableLocalParticipantStatusChecks) {
                 add(LocalParticipantKickedStatusCheck(logger))
             }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/SeleniumStateMachine.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/SeleniumStateMachine.kt
@@ -25,6 +25,7 @@ sealed class SeleniumEvent {
     object FailedToJoinCall : SeleniumEvent()
     object CallEmpty : SeleniumEvent()
     object NoMediaReceived : SeleniumEvent()
+    object IceFailedEvent : SeleniumEvent()
     object ChromeHung : SeleniumEvent()
     object LocalParticipantKicked : SeleniumEvent()
 }
@@ -53,6 +54,9 @@ class SeleniumStateMachine : NotifyingStateMachine() {
             }
             on<SeleniumEvent.NoMediaReceived> {
                 transitionTo(ComponentState.Error(NoMediaReceived))
+            }
+            on<SeleniumEvent.IceFailedEvent> {
+                transitionTo(ComponentState.Error(IceFailed))
             }
             on<SeleniumEvent.LocalParticipantKicked> {
                 transitionTo(ComponentState.Finished)

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -221,6 +221,14 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         }
     }
 
+    /**
+     * Return true if ICE is connected.
+     */
+    fun isIceConnected(): Boolean {
+        val result = driver.executeScript("return APP.conference.getConnectionState()")
+        return result.toString().lowercase() == "connected"
+    }
+
     fun isLocalParticipantKicked(): Boolean {
         val result = driver.executeScript(
             """

--- a/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/IceConnectionStatusCheck.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/status_checks/IceConnectionStatusCheck.kt
@@ -1,0 +1,44 @@
+package org.jitsi.jibri.selenium.status_checks
+
+import org.jitsi.jibri.config.Config
+import org.jitsi.jibri.selenium.SeleniumEvent
+import org.jitsi.jibri.selenium.pageobjects.CallPage
+import org.jitsi.metaconfig.config
+import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.createChildLogger
+import java.time.Clock
+import java.time.Duration
+
+/**
+ * A check for the ICE connection. If ICE is not in the "connected" state for more than [iceConnectionTimeout] then a
+ * [SeleniumEvent.IceFailedEvent] is fired.
+ */
+class IceConnectionStatusCheck(
+    parentLogger: Logger,
+    private val clock: Clock = Clock.systemDefaultZone()
+) : CallStatusCheck {
+    private val logger = createChildLogger(parentLogger)
+    // The last timestamp when ICE was connected. Initialized to give the same timeout for the initial connection.
+    private var timeOfLastSuccess = clock.instant()
+
+    override fun run(callPage: CallPage): SeleniumEvent? {
+        val now = clock.instant()
+
+        if (callPage.isIceConnected()) {
+            timeOfLastSuccess = now
+            return null
+        }
+
+        if (Duration.between(timeOfLastSuccess, now) > iceConnectionTimeout) {
+            logger.warn("ICE has failed and not recovered in $iceConnectionTimeout.")
+            return SeleniumEvent.IceFailedEvent
+        }
+        return null
+    }
+
+    companion object {
+        val iceConnectionTimeout: Duration by config {
+            "jibri.call-status-checks.ice-connection-timeout".from(Config.configSource)
+        }
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -77,10 +77,10 @@ jibri {
     # ttl = 1 hour
   }
   call-status-checks {
-    // If all clients have their audio and video muted and if Jibri does not
+    // If not all clients have their audio and video muted, but Jibri does not
     // detect any data stream (audio or video) comming in, it will stop
     // recording after NO_MEDIA_TIMEOUT expires.
-    no-media-timeout = 30 seconds
+    no-media-timeout = 3 minutes
 
     // If all clients have their audio and video muted, Jibri consideres this
     // as an empty call and stops the recording after ALL_MUTED_TIMEOUT expires.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -90,5 +90,8 @@ jibri {
     // long the call has been empty already. If it has been empty for more than
     // DEFAULT_CALL_EMPTY_TIMEOUT, it will consider it empty and stop the recording.
     default-call-empty-timeout = 30 seconds
+
+    // If ICE hasn't completed, or stays in a state other than "connected" for this amount of time, Jibri will stop.
+    ice-connection-timeout = 30 seconds
   }
 }

--- a/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/IceConnectionStatusCheckTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/status_checks/IceConnectionStatusCheckTest.kt
@@ -1,0 +1,63 @@
+package org.jitsi.jibri.selenium.status_checks
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.jitsi.jibri.helpers.FakeClock
+import org.jitsi.jibri.selenium.SeleniumEvent
+import org.jitsi.jibri.selenium.pageobjects.CallPage
+import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.secs
+
+class IceConnectionStatusCheckTest : ShouldSpec() {
+    private val clock: FakeClock = spyk()
+    private val callPage: CallPage = mockk()
+    private val logger: Logger = mockk(relaxed = true)
+
+    private val check = IceConnectionStatusCheck(logger, clock)
+
+    init {
+        context("When ICE connects") {
+            every { callPage.isIceConnected() } returns true
+            should("not report any event") {
+                repeat(10) {
+                    check.run(callPage) shouldBe null
+                    clock.elapse(1.secs)
+                }
+            }
+        }
+        context("When ICE disconnects") {
+            every { callPage.isIceConnected() } returns false
+            should("not fire an event immediately") {
+                repeat(10) {
+                    check.run(callPage) shouldBe null
+                    clock.elapse(1.secs)
+                }
+            }
+            should("fire an event eventually") {
+                clock.elapse(20.secs)
+                check.run(callPage) shouldBe SeleniumEvent.IceFailedEvent
+            }
+        }
+        context("When ICE disconnects but recovers") {
+            every { callPage.isIceConnected() } returns true
+            check.run(callPage) shouldBe null
+            every { callPage.isIceConnected() } returns false
+            should("not fire an event immediately") {
+                repeat(10) {
+                    check.run(callPage) shouldBe null
+                    clock.elapse(1.secs)
+                }
+            }
+            every { callPage.isIceConnected() } returns true
+            should("not fire an event") {
+                repeat(10) {
+                    check.run(callPage) shouldBe null
+                    clock.elapse(10.secs)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The purpose of the NoMediaTimeout is to check the jibri-jvb connection, but it misfires when a participant's network connection drops (and that participant is the only one unmuted). Checking the ICE connection directly is more simple anyway.


- Add a status check for the ICE connection.
- Remove the NoMediaReceived check.
- ref: Rename MediaReceivedStatusCheck to AllMutedStatusCheck.
- squash: Fix ktlint errors.
