### PR TITLE
fix: Authorization header sending for webhooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <kotest.version>5.3.0</kotest.version>
         <mockk.version>1.10.0</mockk.version>
         <ktor.version>2.0.2-jitsi</ktor.version>
+        <jwt.version>0.11.5</jwt.version>
         <jicoco.version>1.1-113-g4e7ea8b</jicoco.version>
         <jitsi.utils.version>1.0-119-ga7b23ff</jitsi.utils.version>
     </properties>
@@ -180,8 +181,20 @@
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.9.1</version>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- testing -->

--- a/src/test/kotlin/org/jitsi/jibri/util/RefreshingPropertyTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/RefreshingPropertyTest.kt
@@ -16,8 +16,10 @@
 
 package org.jitsi.jibri.util
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.spyk
 import org.jitsi.jibri.helpers.minutes
 import org.jitsi.jibri.helpers.seconds
@@ -62,6 +64,17 @@ class RefreshingPropertyTest : ShouldSpec({
             should("return null") {
                 exObj.prop shouldBe null
             }
+        }
+        context("whose creator function throws an Error") {
+            val exObj = object {
+                val prop: Int? by RefreshingProperty<Int>(Duration.ofSeconds(1), clock) {
+                    throw NoClassDefFoundError("javax.xml.bind.DatatypeConverter")
+                }
+            }
+            val error = shouldThrow<NoClassDefFoundError>() {
+                println(exObj.prop)
+            }
+            error.message shouldContain "javax.xml.bind.DatatypeConverter"
         }
     }
 })


### PR DESCRIPTION
 - the issue was caused by io.jsonwebtoken having a hardcoded call to javax.xml.bind.* packages; these are gone in java 9+. The fix was to simply upgrade the jsonwebtoken library. Use latest, 0.11.5. This also requires a split (api vs impl vs jackson), so add the API as compile dependency and the impl and jackson serializer as runtime dependencies
 - add logging around RefreshingProperty throwing exceptions
 - separate Throwable (unrecoverable, propagate it) vs Exception (return null, rely on next refresh, but log)
 - update unit tests
 - use bearerAuth() instead of header(), to reduce verbosity