### PR TITLE
fix: webhooks JWT recreation after expiry

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -92,7 +92,7 @@ class WebhookClient(
         }
         jwt?.let {
             defaultRequest {
-                bearerAuth(it)
+                bearerAuth("$jwt")
             }
         }
     }


### PR DESCRIPTION
Previous fix has slightly refactored the handling of the JWT header, thereby introducing a regression.
https://community.jitsi.org/t/jibri-is-not-sending-webhook-authorization-header/117184/

When passing the defaultRequest closure we must ensure we supply a block that forces re-evaluation of the `jwt` property, subsequently executing the expiry check in RefreshingProperty. As such, `$jwt` is valid, while `$it` is not, because `it` is resolved only once, when the Client is setup. Whatever value is computed then, is seen as a constant when passed to defaultRequest. `$jwt`, on the other hand, forces re-evaluation every time the default request block is executed, i.e. for every webhook request.