### PR TITLE
refactor: remove hardcoded SIP id

### DIFF
--- a/resources/debian-package/etc/jitsi/jibri/pjsua.config
+++ b/resources/debian-package/etc/jitsi/jibri/pjsua.config
@@ -28,3 +28,4 @@
 --auto-keyframe=30
 --no-stderr
 --log-file=/var/log/jitsi/jibri/pjsua.log
+--id "jibri <sip:jibri@127.0.0.1>"

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -96,8 +96,6 @@ class PjsuaClient(
             command.add("--realm=*")
             command.add("--username=${pjsuaClientParams.sipClientParams.userName.substringBefore('@')}")
             command.add("--password=${pjsuaClientParams.sipClientParams.password}")
-        } else {
-            command.add("--id=${pjsuaClientParams.sipClientParams.displayName} <sip:jibri@127.0.0.1>")
         }
 
         if (pjsuaClientParams.sipClientParams.autoAnswer) {


### PR DESCRIPTION
This commit fixes the issue #496

It removes the hardcoded `--id` (which is `<sip:jibri@127.0.0.1>`) from `Jibri` and puts it into [pjsua.config](https://github.com/jitsi/jibri/blob/master/resources/debian-package/etc/jitsi/jibri/pjsua.config)