### PR TITLE
feat: add the optional contact parameter for pjsua

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
@@ -44,7 +44,12 @@ data class SipClientParams(
     /**
      * The password to use if registration is needed.
      */
-    val password: String? = null
+    val password: String? = null,
+
+    /**
+     * The optional contact address the invitee will be connecting to
+     */
+    val contact: String? = null
 )
 
 abstract class SipClient : StatusPublisher<ComponentState>() {

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -98,6 +98,10 @@ class PjsuaClient(
             command.add("--password=${pjsuaClientParams.sipClientParams.password}")
         }
 
+        if (pjsuaClientParams.sipClientParams.contact != null) {
+            command.add("--contact=${pjsuaClientParams.sipClientParams.contact}")
+        }
+
         if (pjsuaClientParams.sipClientParams.autoAnswer) {
             command.add("--auto-answer-timer=30")
             command.add("--auto-answer=200")


### PR DESCRIPTION
This commit adds an optional `--contact` parameter for `pjsua` client.

When `video-sip-gateway` client is behind a NAT, it may be needed to set `--contact` to inform `invitee` for the accessible endpoint which is not always the same with `inviter`'s SIP address.

This commit allows to set `contact` through `jitsi-component-selector` API.

A sample request may be like the following

```json
{
  "callParams": {
    "callUrlInfo": {
      "baseUrl": "$JITSI_HOST",
      "callName": "$JITSI_ROOM"
    }
  },
  "componentParams": {
    "type": "SIP-JIBRI",
    "region": "default-region",
    "environment": "default-env"
  },
  "metadata": {
    "sipClientParams": {
      "userName": "$INVITER_USERNAME",
      "password": "$INVITER_PASSWORD",
      "contact": "$INVITER_CONTACT",
      "sipAddress": "$INVITEE",
      "displayName": "Caller",
      "autoAnswer": true
    }
  },
  "callLoginParams": {
    "domain": "sip.jitsi.mydomain.com",
    "username": "sip",
    "password": "$PROSODY_SIP_PASSWD"
  }
}
```