### PR TITLE
feat: add the optional proxy parameter for pjsua

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
@@ -49,7 +49,12 @@ data class SipClientParams(
     /**
      * The optional contact address the invitee will be connecting to
      */
-    val contact: String? = null
+    val contact: String? = null,
+
+    /**
+     * The optional address of proxy server
+     */
+    val proxy: String? = null
 )
 
 abstract class SipClient : StatusPublisher<ComponentState>() {

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -98,7 +98,7 @@ class PjsuaClient(
             command.add("--password=${pjsuaClientParams.sipClientParams.password}")
         }
 
-        if (pjsuaClientParams.sipClientParams.contact != null) {
+        if (!pjsuaClientParams.sipClientParams.contact.isNullOrEmpty()) {
             command.add("--contact=${pjsuaClientParams.sipClientParams.contact}")
         }
 

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -102,13 +102,19 @@ class PjsuaClient(
             command.add("--contact=${pjsuaClientParams.sipClientParams.contact}")
         }
 
+        if (!pjsuaClientParams.sipClientParams.proxy.isNullOrEmpty()) {
+            command.add("--proxy=${pjsuaClientParams.sipClientParams.proxy}")
+        }
+
         if (pjsuaClientParams.sipClientParams.autoAnswer) {
             command.add("--auto-answer-timer=30")
             command.add("--auto-answer=200")
         } else {
             // The proxy we'll use for all the outgoing SIP requests;
+            // This proxy will be enabled if --proxy is not set explicitly through API
             // The client should not specify a Route header in the sip INVITE message. Using hide will let the server set the Route header
-            if (pjsuaClientParams.sipClientParams.userName != null) {
+            if (pjsuaClientParams.sipClientParams.proxy == null &&
+                pjsuaClientParams.sipClientParams.userName != null) {
                 command.add(
                     "--proxy=$sipScheme:${pjsuaClientParams.sipClientParams.userName.substringAfter('@')};" +
                         "transport=tcp;hide"


### PR DESCRIPTION
This commit adds an optional `--proxy` parameter for `pjsua` client. It allows to set  SIP `proxy` through `jitsi-component-selector` API.

If there is no `proxy` in the API request, the application still sets the forced proxy to not break the old setups.
`--proxy=...transport=tcp;hide`

A sample request may be like the following

```json
{
  "callParams": {
    "callUrlInfo": {
      "baseUrl": "$JITSI_HOST",
      "callName": "$JITSI_ROOM"
    }
  },
  "componentParams": {
    "type": "SIP-JIBRI",
    "region": "default-region",
    "environment": "default-env"
  },
  "metadata": {
    "sipClientParams": {
      "userName": "$CALLER_USERNAME",
      "password": "$CALLER_PASSWORD",
      "sipAddress": "$CALLEE",
      "displayName": "Caller",
      "proxy": "$SIP_PROXY",
      "autoAnswer": false
    }
  },
  "callLoginParams": {
    "domain": "sip.jitsi.mydomain.com",
    "username": "sip",
    "password": "$PROSODY_SIP_PASSWD"
  }
}
```