### PR TITLE
feat: add the optional auto-answer-timer parameter for pjsua

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/SipClient.kt
@@ -25,16 +25,25 @@ data class SipClientParams(
      * The SIP address we'll be connecting to
      */
     val sipAddress: String = "",
+
     /**
      * The display name used by pjsua as identity when listening for or sending an invite
      * For sending an invite, this should be the name of the entity initiating the invite
      */
     val displayName: String = "",
+
     /**
      * Whether auto-answer is enabled, if it is, the client will listen for
      * incoming invites and will auto answer the first one.
      */
     val autoAnswer: Boolean = false,
+
+    /**
+     * The optional auto-answer-timer in seconds.
+     * If auto-answer is enabled, the client will listen for incoming invites
+     * during this time.
+     */
+    val autoAnswerTimer: Long? = 30,
 
     /**
      * The username to use if registration is needed.

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -107,7 +107,7 @@ class PjsuaClient(
         }
 
         if (pjsuaClientParams.sipClientParams.autoAnswer) {
-            command.add("--auto-answer-timer=30")
+            command.add("--auto-answer-timer=${pjsuaClientParams.sipClientParams.autoAnswerTimer}")
             command.add("--auto-answer=200")
         } else {
             // The proxy we'll use for all the outgoing SIP requests;


### PR DESCRIPTION
This commit allows to set `--auto-answer-timer` of `pjsua` through `jitsi-component-selector` API. Normally `auto-answer-timer` has a hardcoded value which is `30` secs and this doesn't suit all use-cases.

After this commit, it is possible to overwrite the default value (_which is 30 secs_) by setting it in API payload. As an example

```json
{
  "callParams": {
    "callUrlInfo": {
      "baseUrl": "$JITSI_HOST",
      "callName": "$JITSI_ROOM?jwt=$TOKEN"
    }
  },
  "componentParams": {
    "type": "SIP-JIBRI",
    "region": "default-region",
    "environment": "default-env"
  },
  "metadata": {
    "sipClientParams": {
      "sipAddress": "sip:jibri@127.0.0.1",
      "displayName": "$DISPLAY_NAME",
      "autoAnswer": true,
      "autoAnswerTimer": 600
    }
  }
}

```