### PR TITLE
refactor: dont show curl progress in jibri log

### DIFF
--- a/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh
+++ b/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh
@@ -5,4 +5,4 @@ CONF="/etc/jitsi/jibri/jibri.conf"
 PORT=$(hocon -f $CONF get jibri.api.http.internal-api-port 2>/dev/null || true)
 [[ -z "$PORT" ]] && PORT=3333
 
-curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/gracefulShutdown
+curl -sX POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/gracefulShutdown

--- a/resources/debian-package/opt/jitsi/jibri/reload.sh
+++ b/resources/debian-package/opt/jitsi/jibri/reload.sh
@@ -5,4 +5,4 @@ CONF="/etc/jitsi/jibri/jibri.conf"
 PORT=$(hocon -f $CONF get jibri.api.http.internal-api-port 2>/dev/null || true)
 [[ -z "$PORT" ]] && PORT=3333
 
-curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/notifyConfigChanged
+curl -sX POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/notifyConfigChanged

--- a/resources/debian-package/opt/jitsi/jibri/shutdown.sh
+++ b/resources/debian-package/opt/jitsi/jibri/shutdown.sh
@@ -5,4 +5,4 @@ CONF="/etc/jitsi/jibri/jibri.conf"
 PORT=$(hocon -f $CONF get jibri.api.http.internal-api-port 2>/dev/null || true)
 [[ -z "$PORT" ]] && PORT=3333
 
-curl -X POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/shutdown
+curl -sX POST http://127.0.0.1:$PORT/jibri/api/internal/v1.0/shutdown


### PR DESCRIPTION
Run `curl` in silent mode to not add the `curl` progress info into `jibri` service logs,

_such as_
```
graceful_shutdown.sh[1053]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
graceful_shutdown.sh[1053]:                                  Dload  Upload   Total   Spent    Left  Speed
```