### PR TITLE
fix:Set the recording timestamp,so can use stream_tags[creation_time]

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Commands.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/Commands.kt
@@ -36,6 +36,7 @@ fun getFfmpegCommandLinux(ffmpegExecutorParams: FfmpegExecutorParams, sink: Sink
         *sink.options, "-pix_fmt", "yuv420p", "-r", ffmpegExecutorParams.framerate.toString(),
         "-crf", ffmpegExecutorParams.h264ConstantRateFactor.toString(),
         "-g", ffmpegExecutorParams.gopSize.toString(), "-tune", "zerolatency",
+        "-timestamp", "now",
         "-f", sink.format, sink.path
     )
 }
@@ -60,6 +61,7 @@ fun getFfmpegCommandMac(ffmpegExecutorParams: FfmpegExecutorParams, sink: Sink):
         "-c:v", "libx264", "-preset", ffmpegExecutorParams.videoEncodePreset,
         *sink.options, "-pix_fmt", "yuv420p", "-crf", ffmpegExecutorParams.h264ConstantRateFactor.toString(),
         "-g", ffmpegExecutorParams.gopSize.toString(), "-tune", "zerolatency",
+        "-timestamp", "now",
         "-f", sink.format, sink.path
     )
 }


### PR DESCRIPTION
Currently recording video files, there is no recording start time label field, add timestamp options , then through the ffprobe command,could get the recording time.
ffprobe -v quiet -show_entries stream_tags=creation_time -of default=noprint_wrappers=1:nokey=1 -i [recordfile] | head -1
