### PR TITLE
fix: add sudo into the dependency list

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9)
 
 Package: jibri
 Architecture: all
-Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-video-dummy, procps, ruby-hocon
+Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-video-dummy, procps, ruby-hocon, sudo
 Description: Jibri
  Jibri can be used to capture data from a Jitsi Meet conference and record it to a file or stream it to a url


### PR DESCRIPTION
There is a new dependency because of the newly added [ExecStartPre](https://github.com/jitsi/jibri/blob/master/resources/debian-package/etc/systemd/system/jibri.service#L10). This PR adds `sudo` into the dependency list.