### PR TITLE
remove xdotool dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9)
 
 Package: jibri
 Architecture: all
-Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xdotool, xserver-xorg-video-dummy, procps, ruby-hocon
+Depends: default-jre-headless | java8-runtime-headless | java8-runtime, ffmpeg, curl, alsa-utils, icewm, xserver-xorg-video-dummy, procps, ruby-hocon
 Description: Jibri
  Jibri can be used to capture data from a Jitsi Meet conference and record it to a file or stream it to a url


### PR DESCRIPTION
xdotool is not used more and debian package doesn't depend on it