### PR TITLE
Alternative Recording Mode Using Local Recording

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -166,6 +166,7 @@ val RECORDING_URL_OPTIONS = listOf(
  */
 class JibriSelenium(
     parentLogger: Logger,
+    val sessionId: String,
     private val jibriSeleniumOptions: JibriSeleniumOptions = JibriSeleniumOptions()
 ) : StatusPublisher<ComponentState>() {
     private val logger = createChildLogger(parentLogger)
@@ -187,6 +188,10 @@ class JibriSelenium(
     init {
         System.setProperty("webdriver.chrome.logfile", "/tmp/chromedriver.log")
         val chromeOptions = ChromeOptions()
+        val prefs = HashMap<String, Any>()
+        prefs["download.default_directory"] = "/recordings/$sessionId"
+        prefs["download.prompt_for_download"] = false
+        chromeOptions.setExperimentalOption("prefs", prefs)
         chromeOptions.addArguments(chromeOpts)
         chromeOptions.setExperimentalOption("w3c", false)
         chromeOptions.addArguments(jibriSeleniumOptions.extraChromeCommandLineFlags)
@@ -364,6 +369,8 @@ class JibriSelenium(
         chromeDriver.quit()
         logger.info("Chrome driver quit")
     }
+
+    fun getChromeDriver(): ChromeDriver = chromeDriver
 
     companion object {
         private val browserOutputLogger = getLoggerWithHandler("browser", BrowserFileHandler())

--- a/src/main/kotlin/org/jitsi/jibri/selenium/util/SeleniumUtils.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/util/SeleniumUtils.kt
@@ -1,0 +1,81 @@
+package org.jitsi.jibri.selenium.util
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedCondition
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+
+/**
+ * Utility class.
+ * @author Damian Minkov
+ * @author Pawel Domas
+ */
+object SeleniumUtils {
+    var IS_LINUX: Boolean = false
+
+    var IS_MAC: Boolean = false
+
+    init {
+        // OS
+        val osName: String? = System.getProperty("os.name")
+
+        when {
+            osName == null -> {
+                IS_LINUX = false
+                IS_MAC = false
+            }
+            osName.startsWith(prefix = "Linux") -> {
+                IS_LINUX = true
+                IS_MAC = false
+            }
+            osName.startsWith(prefix = "Mac") -> {
+                IS_LINUX = false
+                IS_MAC = true
+            }
+            else -> {
+                IS_LINUX = false
+                IS_MAC = false
+            }
+        }
+    }
+
+    /**
+     * Click an element on the page by first checking for visibility and then
+     * checking for clickability.
+     *
+     * @param driver the `WebDriver`.
+     * @param by the search query for the element
+     */
+    fun click(driver: WebDriver, by: By) {
+        waitForElementBy(driver = driver, by = by, timeout = 10)
+        val wait = WebDriverWait(driver, 10)
+        val element: WebElement = wait.until(ExpectedConditions.elementToBeClickable(by))
+        element.click()
+    }
+
+    /**
+     * Waits until an element becomes available and return it.
+     * @param driver the `WebDriver`.
+     * @param by the xpath to search for the element
+     * @param timeout the time to wait for the element in seconds.
+     * @return WebElement the found element
+     */
+    private fun waitForElementBy(driver: WebDriver, by: By, timeout: Long): WebElement? {
+        var foundElement: WebElement? = null
+        WebDriverWait(driver, timeout)
+            .until<Boolean>(ExpectedCondition<Boolean?> { d: WebDriver? ->
+                val elements: List<WebElement> = d!!.findElements(by)
+                when {
+                    elements.isNotEmpty() -> {
+                        foundElement = elements[0]
+                        return@ExpectedCondition true
+                    }
+                    else -> return@ExpectedCondition false
+                }
+            })
+
+        return foundElement
+    }
+}

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
@@ -43,7 +43,13 @@ import org.jitsi.xmpp.extensions.jibri.JibriIq
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.listDirectoryEntries
+import org.jitsi.jibri.selenium.util.SeleniumUtils
+import org.openqa.selenium.By
+import org.openqa.selenium.chrome.ChromeDriver
 
 /**
  * Parameters needed for starting a [FileRecordingJibriService]
@@ -106,7 +112,7 @@ class FileRecordingJibriService(
     }
 
     private val capturer = capturer ?: FfmpegCapturer(logger)
-    private val jibriSelenium = jibriSelenium ?: JibriSelenium(logger)
+    private val jibriSelenium = jibriSelenium ?: JibriSelenium(logger, fileRecordingParams.sessionId)
 
     /**
      * The [Sink] this class will use to model the file on the filesystem
@@ -170,7 +176,8 @@ class FileRecordingJibriService(
                 jibriSelenium.addToPresence("session_id", fileRecordingParams.sessionId)
                 jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.FILE.toString())
                 jibriSelenium.sendPresence()
-                capturer.start(sink)
+                startAndStopRecordingWithSelenium(driver = jibriSelenium.getChromeDriver())
+                publishStatus(status = ComponentState.Running)
             } catch (t: Throwable) {
                 logger.error("Error while setting fields in presence", t)
                 publishStatus(ComponentState.Error(ErrorSettingPresenceFields))
@@ -180,8 +187,33 @@ class FileRecordingJibriService(
 
     override fun stop() {
         logger.info("Stopping capturer")
-        capturer.stop()
+        startAndStopRecordingWithSelenium(driver = jibriSelenium.getChromeDriver(), type = "stop")
         logger.info("Quitting selenium")
+
+        var found = false
+        val startTime: Long = System.currentTimeMillis()
+        while (!Files.exists(sink.file)) {
+            sessionRecordingDirectory.listDirectoryEntries()
+                .forEach { entry: Path ->
+                    run {
+                        val fileName: Path = entry.fileName
+                        when {
+                            fileName.toString().endsWith(suffix = ".webm") ->
+                                logger.info { "webm found: $entry. File is renaming from: ${sink.file}" }
+                                    .run {
+                                        found = true
+                                        sink.file = sessionRecordingDirectory.resolve(entry)
+                                        sink.format = "webm"
+                                    }
+
+                            else -> logger.warn { "Unhandled file: $fileName" }
+                        }
+                    }
+                }
+            if (found || System.currentTimeMillis() - startTime > 30 * 1_000)
+                break
+            TimeUnit.SECONDS.sleep(1).also { logger.info { "Media was not found, sleeping..." } }
+        }
 
         // It's possible that the service was stopped before we even wrote anything, so check if we actually wrote
         // any data to disk.  If not, we'll skip writing the metadata and running the finalize script and instead
@@ -192,7 +224,7 @@ class FileRecordingJibriService(
             try {
                 Files.delete(sessionRecordingDirectory)
             } catch (t: Throwable) {
-                logger.error("Problem deleting session recording directory", t)
+                logger.error("Problem deleting session recording directory. ${t.message}")
             }
             jibriSelenium.leaveCallAndQuitBrowser()
             return
@@ -203,7 +235,7 @@ class FileRecordingJibriService(
         } catch (t: Throwable) {
             logger.error(
                 "An error occurred while trying to get the participants list, proceeding with " +
-                    "an empty participants list",
+                    "an empty participants list. ${t.message}",
                 t
             )
             listOf<Map<String, Any>>()
@@ -231,6 +263,20 @@ class FileRecordingJibriService(
         jibriSelenium.leaveCallAndQuitBrowser()
         logger.info("Finalizing the recording")
         jibriServiceFinalizer?.doFinalize()
+    }
+
+    /**
+     * Starts or stops local recording with Selenium.
+
+     * @param driver The ChromeDriver instance.
+     * @param type The type of action to perform, either "start" or "stop" default is "start"
+     */
+    private fun startAndStopRecordingWithSelenium(driver: ChromeDriver, type: String = "start") {
+        logger.info { "startAndStopRecordingWithSelenium called. id: ${jibriSelenium.sessionId}, type: $type" }
+        SeleniumUtils.click(driver, By.id("more-actions-id"))
+        SeleniumUtils.click(driver, By.id("menu-item-local-recording"))
+        SeleniumUtils.click(driver, By.id("modal-dialog-ok-button"))
+        logger.info { "Sleeping 5 seconds..." }.run { TimeUnit.SECONDS.sleep(5) }
     }
 }
 

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -74,6 +74,7 @@ class SipGatewayJibriService(
      */
     private val jibriSelenium = jibriSelenium ?: JibriSelenium(
         logger,
+        "",
         JibriSeleniumOptions(
             displayName = if (sipGatewayServiceParams.callParams.displayName.isNotBlank()) {
                 sipGatewayServiceParams.callParams.displayName

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -78,7 +78,7 @@ class StreamingJibriService(
     }
     private val capturer = FfmpegCapturer(logger)
     private val sink: Sink
-    private val jibriSelenium = JibriSelenium(logger)
+    private val jibriSelenium = JibriSelenium(logger, streamingParams.sessionId)
 
     private val rtmpAllowList: List<Pattern> by config {
         "jibri.streaming.rtmp-allow-list".from(Config.configSource)

--- a/src/main/kotlin/org/jitsi/jibri/sink/impl/FileSink.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sink/impl/FileSink.kt
@@ -30,14 +30,14 @@ import java.time.format.DateTimeFormatter
  * over the value anyway.  Because of that I just made the value hard-coded.
  */
 class FileSink(recordingsDirectory: Path, callName: String, extension: String = "mp4") : Sink {
-    val file: Path
+    var file: Path
     init {
         val suffix = "_${LocalDateTime.now().format(TIMESTAMP_FORMATTER)}.$extension"
         val filename = "${callName.take(MAX_FILENAME_LENGTH - suffix.length)}$suffix"
         file = recordingsDirectory.resolve(filename)
     }
     override val path: String = file.toString()
-    override val format: String = extension
+    override var format: String = extension
     override val options: Array<String> = arrayOf(
         "-profile:v",
         "main",


### PR DESCRIPTION
## Summary:
Using local-recording feature instead of ffmpeg to reduce memory usage size to have more instance of jibri. It is tested in our environment and works better than ffmpeg.

## Issue(s) addressed:
"N/A"

## Testing:
Tested in our environment for performance for a long time, it is working great as expected. I did not write any unit or integration test

## Checklist:
[x] I have reviewed the code and tested it thoroughly.
[x] I have followed the coding style guide.
[ ] I have updated the documentation to reflect the changes.
[ ] I have added unit tests for the new code.
[x] I have run the build and test scripts.

## Additional notes:
- `--use-fake-device-for-media-stream` flag should be added in docker-jitsi-meet application since it is configured to have the data as user input. Also frontend side should be changed reflectively with this release.
- There is no dependency changes
- Maybe using this feature can be optional along with ffmpeg

## Thanks for reviewing! & Hope this helps

The community ticket: https://community.jitsi.org/t/new-recording-implementation-using-local-recording-instead-of-ffmpeg/128652