### PR TITLE
fix(CallPage) fix use of deprecated API

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -342,7 +342,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         val result = driver.executeScript(
             """
             try {
-                APP.conference._room.room.addToPresence(
+                APP.conference._room.room.addOrReplaceInPresence(
                     '$key',
                     {
                         value: '$value'


### PR DESCRIPTION
The addToPresence internal function was mistakenly renamed. Rather than
bring it back, let's switch to its replacement, since it has existed for
years already.
