### PR TITLE
feat: add audio-only recording mode to reduce CPU usage

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturer.kt
+++ b/src/main/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturer.kt
@@ -57,17 +57,26 @@ class FfmpegCapturer(
         const val COMPONENT_ID = "Ffmpeg Capturer"
         private val ffmpegOutputLogger = getLoggerWithHandler("ffmpeg", FfmpegFileHandler())
 
+        val enableVideo: Boolean by config {
+            "jibri.ffmpeg.enable-video".from(Config.configSource)
+        }
         val commandLinuxRecording: List<String> by config {
             "jibri.ffmpeg.command-linux-recording".from(Config.configSource)
         }
         val commandLinuxStreaming: List<String> by config {
             "jibri.ffmpeg.command-linux-streaming".from(Config.configSource)
         }
+        val commandLinuxRecordingAudioOnly: List<String> by config {
+            "jibri.ffmpeg.command-linux-recording-audio-only".from(Config.configSource)
+        }
         val commandMacRecording: List<String> by config {
             "jibri.ffmpeg.command-mac-recording".from(Config.configSource)
         }
         val commandMacStreaming: List<String> by config {
             "jibri.ffmpeg.command-mac-streaming".from(Config.configSource)
+        }
+        val commandMacRecordingAudioOnly: List<String> by config {
+            "jibri.ffmpeg.command-mac-recording-audio-only".from(Config.configSource)
         }
     }
 
@@ -78,14 +87,14 @@ class FfmpegCapturer(
             OsType.MAC -> { sink: Sink ->
                 when (sink) {
                     is StreamSink -> commandMacStreaming
-                    is FileSink -> commandMacRecording
+                    is FileSink -> if (enableVideo) commandMacRecording else commandMacRecordingAudioOnly
                     else -> throw UnsupportedSinkTypeException(sink)
                 } + listOf(sink.path)
             }
             OsType.LINUX -> { sink: Sink ->
                 when (sink) {
                     is StreamSink -> commandLinuxStreaming
-                    is FileSink -> commandLinuxRecording
+                    is FileSink -> if (enableVideo) commandLinuxRecording else commandLinuxRecordingAudioOnly
                     else -> throw UnsupportedSinkTypeException(sink)
                 } + listOf(sink.path)
             }

--- a/src/main/kotlin/org/jitsi/jibri/sink/impl/FileSink.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sink/impl/FileSink.kt
@@ -42,7 +42,12 @@ class FileSink(recordingsDirectory: Path, callName: String) : Sink {
     override val path: String = file.toString()
 
     companion object {
-        val recordingExtension: String by config("jibri.ffmpeg.recording-extension".from(Config.configSource))
+        private val enableVideo: Boolean by config("jibri.ffmpeg.enable-video".from(Config.configSource))
+        private val videoExtension: String by config("jibri.ffmpeg.recording-extension".from(Config.configSource))
+        private val audioOnlyExtension: String by config(
+            "jibri.ffmpeg.recording-extension-audio-only".from(Config.configSource)
+        )
+        val recordingExtension: String get() = if (enableVideo) videoExtension else audioOnlyExtension
         private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
         const val MAX_FILENAME_LENGTH = 125
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -131,6 +131,32 @@ jibri {
     command-linux-streaming = ${jibri.ffmpeg.ffmpeg} ${jibri.ffmpeg.input-linux} ${jibri.ffmpeg.audio-params} ${jibri.ffmpeg.video-params-streaming}
     command-mac-recording = ${jibri.ffmpeg.ffmpeg} ${jibri.ffmpeg.input-mac} ${jibri.ffmpeg.audio-params} ${jibri.ffmpeg.video-params-recording}
     command-mac-streaming = ${jibri.ffmpeg.ffmpeg} ${jibri.ffmpeg.input-mac} ${jibri.ffmpeg.audio-params} ${jibri.ffmpeg.video-params-streaming}
+
+    // Whether to capture video in recordings. Set to false for audio-only recording,
+    // which significantly reduces CPU and storage requirements.
+    enable-video = true
+
+    // Input parameters for audio-only recording on Linux (no x11grab video capture)
+    input-linux-audio-only = [
+      "-f", ${jibri.ffmpeg.audio-source}
+      "-thread_queue_size", ${jibri.ffmpeg.queue-size}
+      "-i", ${jibri.ffmpeg.audio-device}
+    ]
+    // Input parameters for audio-only recording on macOS (audio device only)
+    input-mac-audio-only = [
+      "-thread_queue_size", ${jibri.ffmpeg.queue-size}
+      "-f", "avfoundation"
+      "-i", ":default"
+    ]
+    // Container format for audio-only output
+    recording-format-audio-only = "mp4"
+    // File extension for audio-only recording
+    recording-extension-audio-only = "m4a"
+    // Output parameters for audio-only recording (suppress video stream, set format)
+    audio-only-output-params = [ "-vn", "-f", ${jibri.ffmpeg.recording-format-audio-only} ]
+    // Audio-only recording commands
+    command-linux-recording-audio-only = ${jibri.ffmpeg.ffmpeg} ${jibri.ffmpeg.input-linux-audio-only} ${jibri.ffmpeg.audio-params} ${jibri.ffmpeg.audio-only-output-params}
+    command-mac-recording-audio-only = ${jibri.ffmpeg.ffmpeg} ${jibri.ffmpeg.input-mac-audio-only} ${jibri.ffmpeg.audio-params} ${jibri.ffmpeg.audio-only-output-params}
   }
   chrome {
     // The flags which will be passed to chromium when launching

--- a/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/capture/ffmpeg/FfmpegCapturerTest.kt
@@ -24,13 +24,16 @@ import io.kotest.matchers.collections.contain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.slot
+import io.mockk.unmockkObject
 import io.mockk.verify
 import org.jitsi.jibri.capture.UnsupportedOsException
 import org.jitsi.jibri.sink.Sink
@@ -172,6 +175,54 @@ internal class FfmpegCapturerTest : ShouldSpec() {
                     val commandCaptor = slot<List<String>>()
                     verify { ffmpeg.launch(capture(commandCaptor), any()) }
                     commandCaptor.captured should contain("avfoundation")
+                }
+            }
+        }
+        context("on linux with audio-only recording") {
+            every { osDetector.getOsType() } returns OsType.LINUX
+            mockkObject(FfmpegCapturer.Companion)
+            every { FfmpegCapturer.enableVideo } returns false
+            val ffmpegCapturer = createCapturer()
+            afterSpec { unmockkObject(FfmpegCapturer.Companion) }
+            context("the command") {
+                should("not include x11grab") {
+                    ffmpegCapturer.start(sink)
+                    val commandCaptor = slot<List<String>>()
+                    verify { ffmpeg.launch(capture(commandCaptor), any()) }
+                    commandCaptor.captured shouldNot contain("x11grab")
+                }
+                should("include alsa audio capture") {
+                    ffmpegCapturer.start(sink)
+                    val commandCaptor = slot<List<String>>()
+                    verify { ffmpeg.launch(capture(commandCaptor), any()) }
+                    commandCaptor.captured should contain("alsa")
+                }
+                should("suppress video output with -vn") {
+                    ffmpegCapturer.start(sink)
+                    val commandCaptor = slot<List<String>>()
+                    verify { ffmpeg.launch(capture(commandCaptor), any()) }
+                    commandCaptor.captured should contain("-vn")
+                }
+            }
+        }
+        context("on mac with audio-only recording") {
+            every { osDetector.getOsType() } returns OsType.MAC
+            mockkObject(FfmpegCapturer.Companion)
+            every { FfmpegCapturer.enableVideo } returns false
+            val ffmpegCapturer = createCapturer()
+            afterSpec { unmockkObject(FfmpegCapturer.Companion) }
+            context("the command") {
+                should("not include avfoundation video input") {
+                    ffmpegCapturer.start(sink)
+                    val commandCaptor = slot<List<String>>()
+                    verify { ffmpeg.launch(capture(commandCaptor), any()) }
+                    commandCaptor.captured shouldNot contain("-framerate")
+                }
+                should("suppress video output with -vn") {
+                    ffmpegCapturer.start(sink)
+                    val commandCaptor = slot<List<String>>()
+                    verify { ffmpeg.launch(capture(commandCaptor), any()) }
+                    commandCaptor.captured should contain("-vn")
                 }
             }
         }

--- a/src/test/kotlin/org/jitsi/jibri/sink/impl/FileSinkTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/sink/impl/FileSinkTest.kt
@@ -22,7 +22,11 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldStartWith
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlin.random.Random
 
 internal class FileSinkTest : ShouldSpec() {
@@ -43,6 +47,15 @@ internal class FileSinkTest : ShouldSpec() {
             val sink = FileSink(fs.getPath("/tmp/xxx"), reallyLongCallName)
             should("not generate a filename longer than the max file length") {
                 sink.file.fileName.toString().length shouldBe FileSink.MAX_FILENAME_LENGTH
+            }
+        }
+        context("when audio-only recording is enabled") {
+            mockkObject(FileSink.Companion)
+            every { FileSink.recordingExtension } returns "m4a"
+            afterSpec { unmockkObject(FileSink.Companion) }
+            val sink = FileSink(fs.getPath("/tmp/xxx"), "callname")
+            should("use the m4a file extension") {
+                sink.path.shouldEndWith(".m4a")
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds a configurable audio-only recording mode that skips video capture and encoding entirely. This reduces CPU and storage requirements, making Jibri viable on lower-spec machines and ideal for use cases like meeting transcription.

## Changes

- `reference.conf`: adds `enable-video` flag (default `true`) and audio-only FFmpeg input/output commands for Linux and macOS
- `FfmpegCapturer`: selects audio-only command when `enable-video = false`
- `FileSink`: uses `.m4a` extension for audio-only recordings
- Tests for both new code paths

## Usage

Set in `jibri.conf`:
jibri.ffmpeg.enable-video = false

Output files use `.m4a` extension (AAC audio in MPEG-4 container).

## Motivation

Recording a Jitsi meeting for transcription purposes does not require video.
