### PR TITLE
fix: Don't advertise IDLE until ChromeDriver is validated at startup

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -28,6 +28,7 @@ import org.jitsi.jibri.config.Config
 import org.jitsi.jibri.config.XmppEnvironmentConfig
 import org.jitsi.jibri.config.loadConfigFromFile
 import org.jitsi.jibri.config.toXmppEnvironment
+import org.jitsi.jibri.environment.EnvironmentChecker
 import org.jitsi.jibri.status.ComponentBusyStatus
 import org.jitsi.jibri.status.ComponentHealthStatus
 import org.jitsi.jibri.status.JibriStatusManager
@@ -143,6 +144,17 @@ fun main(args: Array<String>) {
             .convertFrom<List<com.typesafe.config.Config>> { envConfigs -> envConfigs.map { it.toXmppEnvironment() } }
     }.get()
 
+    // Environment startup check: register as UNHEALTHY before XMPP APIs start
+    // so the initial MUC presence advertises UNHEALTHY until ChromeDriver is validated
+    val startupCheckEnabled = configSupplier<Boolean> {
+        "jibri.chrome.startup-check".from(Config.configSource)
+    }.get()
+    val environmentChecker = if (startupCheckEnabled) {
+        EnvironmentChecker(jibriStatusManager)
+    } else {
+        null
+    }
+
     // XmppApi
     val xmppApi = XmppApi(
         jibriManager = jibriManager,
@@ -150,6 +162,13 @@ fun main(args: Array<String>) {
         jibriStatusManager = jibriStatusManager
     )
     xmppApi.start()
+
+    // Run ChromeDriver validation probe in background after XMPP connections are established
+    environmentChecker?.let { checker ->
+        TaskPools.ioPool.submit {
+            checker.validate()
+        }
+    }
 
     logger.info("Using port ${HttpApi.port} for HTTP API")
 

--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -147,7 +147,7 @@ fun main(args: Array<String>) {
     // Environment startup check: register as UNHEALTHY before XMPP APIs start
     // so the initial MUC presence advertises UNHEALTHY until ChromeDriver is validated
     val startupCheckEnabled = configSupplier<Boolean> {
-        "jibri.chrome.startup-check".from(Config.configSource)
+        "jibri.chrome.startup-check.enabled".from(Config.configSource)
     }.get()
     val environmentChecker = if (startupCheckEnabled) {
         EnvironmentChecker(jibriStatusManager)

--- a/src/main/kotlin/org/jitsi/jibri/environment/EnvironmentChecker.kt
+++ b/src/main/kotlin/org/jitsi/jibri/environment/EnvironmentChecker.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.environment
+
+import org.jitsi.jibri.config.Config
+import org.jitsi.jibri.status.ComponentHealthStatus
+import org.jitsi.jibri.status.JibriStatusManager
+import org.jitsi.metaconfig.config
+import org.jitsi.metaconfig.from
+import org.jitsi.utils.logging2.createLogger
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeDriverService
+import org.openqa.selenium.chrome.ChromeOptions
+
+/**
+ * Validates that the environment is ready to handle recording/streaming requests
+ * by probing ChromeDriver at startup. Registers as UNHEALTHY until validation
+ * succeeds, preventing Jicofo from dispatching requests to a Jibri that isn't
+ * actually ready.
+ */
+class EnvironmentChecker(
+    private val jibriStatusManager: JibriStatusManager,
+    private val probeChrome: () -> Unit = ::defaultProbeChrome
+) {
+    private val logger = createLogger()
+
+    init {
+        jibriStatusManager.updateHealth(
+            COMPONENT_ID,
+            ComponentHealthStatus.UNHEALTHY,
+            "Startup validation pending"
+        )
+    }
+
+    /**
+     * Attempt to start and immediately quit ChromeDriver to validate the environment.
+     * Retries up to [maxAttempts] times with [retryDelayMs] between attempts.
+     * Default values are read from config to allow operators to tune for their
+     * environment (e.g., slow Xvfb startup after reboot).
+     */
+    fun validate(maxAttempts: Int = configMaxAttempts, retryDelayMs: Long = configRetryDelayMs) {
+        for (attempt in 1..maxAttempts) {
+            logger.info("ChromeDriver startup check attempt $attempt/$maxAttempts")
+            try {
+                probeChrome()
+                logger.info("ChromeDriver startup check passed")
+                jibriStatusManager.updateHealth(COMPONENT_ID, ComponentHealthStatus.HEALTHY)
+                return
+            } catch (t: Throwable) {
+                logger.error("ChromeDriver startup check failed (attempt $attempt/$maxAttempts)", t)
+                if (attempt < maxAttempts) {
+                    Thread.sleep(retryDelayMs)
+                }
+            }
+        }
+        logger.error("ChromeDriver startup check failed after $maxAttempts attempts, Jibri will remain UNHEALTHY")
+        jibriStatusManager.updateHealth(
+            COMPONENT_ID,
+            ComponentHealthStatus.UNHEALTHY,
+            "ChromeDriver failed to start after $maxAttempts attempts"
+        )
+    }
+
+    companion object {
+        const val COMPONENT_ID = "EnvironmentCheck"
+        private const val DISPLAY = ":0"
+        private val chromeFlags: List<String> by config("jibri.chrome.flags".from(Config.configSource))
+        private val configMaxAttempts: Int by config(
+            "jibri.chrome.startup-check-max-attempts".from(Config.configSource)
+        )
+        private val configRetryDelayMs: Long by config(
+            "jibri.chrome.startup-check-retry-delay".from(Config.configSource)
+        )
+
+        /**
+         * Default probe: mirrors the ChromeDriver setup in JibriSelenium to validate
+         * that Chrome and ChromeDriver are available and functional.
+         */
+        private fun defaultProbeChrome() {
+            val chromeOptions = ChromeOptions()
+            chromeOptions.addArguments(chromeFlags)
+            val chromeDriverService = ChromeDriverService.Builder()
+                .withEnvironment(mapOf("DISPLAY" to DISPLAY))
+                .build()
+            var driver: ChromeDriver? = null
+            try {
+                driver = ChromeDriver(chromeDriverService, chromeOptions)
+            } finally {
+                try {
+                    driver?.quit()
+                } catch (_: Throwable) {
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/jitsi/jibri/environment/EnvironmentChecker.kt
+++ b/src/main/kotlin/org/jitsi/jibri/environment/EnvironmentChecker.kt
@@ -80,10 +80,10 @@ class EnvironmentChecker(
         private const val DISPLAY = ":0"
         private val chromeFlags: List<String> by config("jibri.chrome.flags".from(Config.configSource))
         private val configMaxAttempts: Int by config(
-            "jibri.chrome.startup-check-max-attempts".from(Config.configSource)
+            "jibri.chrome.startup-check.max-attempts".from(Config.configSource)
         )
         private val configRetryDelayMs: Long by config(
-            "jibri.chrome.startup-check-retry-delay".from(Config.configSource)
+            "jibri.chrome.startup-check.retry-delay".from(Config.configSource)
         )
 
         /**

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -141,6 +141,14 @@ jibri {
       "--enabled",
       "--autoplay-policy=no-user-gesture-required"
     ]
+    // Validate that ChromeDriver can start before advertising availability.
+    // When enabled, Jibri reports UNHEALTHY until ChromeDriver validation succeeds.
+    startup-check = true
+    // Number of times to retry the ChromeDriver startup check before giving up.
+    // After a reboot, Xvfb/Chrome may need time to become available.
+    startup-check-max-attempts = 6
+    // Delay in milliseconds between startup check retry attempts.
+    startup-check-retry-delay = 10000
   }
   stats {
     enable-stats-d = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -143,12 +143,14 @@ jibri {
     ]
     // Validate that ChromeDriver can start before advertising availability.
     // When enabled, Jibri reports UNHEALTHY until ChromeDriver validation succeeds.
-    startup-check = true
-    // Number of times to retry the ChromeDriver startup check before giving up.
-    // After a reboot, Xvfb/Chrome may need time to become available.
-    startup-check-max-attempts = 6
-    // Delay in milliseconds between startup check retry attempts.
-    startup-check-retry-delay = 10000
+    startup-check {
+      enabled = true
+      // Number of times to retry the ChromeDriver startup check before giving up.
+      // After a reboot, Xvfb/Chrome may need time to become available.
+      max-attempts = 6
+      // Delay in milliseconds between startup check retry attempts.
+      retry-delay = 10000
+    }
   }
   stats {
     enable-stats-d = true

--- a/src/test/kotlin/org/jitsi/jibri/environment/EnvironmentCheckerTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/environment/EnvironmentCheckerTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.jibri.environment
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.jibri.status.ComponentHealthStatus
+import org.jitsi.jibri.status.JibriStatusManager
+
+class EnvironmentCheckerTest : ShouldSpec() {
+    init {
+        context("EnvironmentChecker") {
+            context("on construction") {
+                should("register as UNHEALTHY in the status manager") {
+                    val statusManager = JibriStatusManager()
+                    EnvironmentChecker(statusManager) { }
+                    statusManager.overallStatus.health.healthStatus shouldBe ComponentHealthStatus.UNHEALTHY
+                    statusManager.overallStatus.health.details[EnvironmentChecker.COMPONENT_ID]
+                        ?.healthStatus shouldBe ComponentHealthStatus.UNHEALTHY
+                }
+            }
+
+            context("validate") {
+                should("transition to HEALTHY when ChromeDriver probe succeeds") {
+                    val statusManager = JibriStatusManager()
+                    val checker = EnvironmentChecker(statusManager) { }
+
+                    statusManager.overallStatus.health.healthStatus shouldBe ComponentHealthStatus.UNHEALTHY
+
+                    checker.validate(maxAttempts = 1, retryDelayMs = 0)
+
+                    statusManager.overallStatus.health.healthStatus shouldBe ComponentHealthStatus.HEALTHY
+                    statusManager.overallStatus.health.details[EnvironmentChecker.COMPONENT_ID]
+                        ?.healthStatus shouldBe ComponentHealthStatus.HEALTHY
+                }
+
+                should("remain UNHEALTHY when ChromeDriver probe fails all attempts") {
+                    val statusManager = JibriStatusManager()
+                    val checker = EnvironmentChecker(statusManager) {
+                        throw RuntimeException("ChromeDriver failed to start")
+                    }
+
+                    checker.validate(maxAttempts = 2, retryDelayMs = 0)
+
+                    statusManager.overallStatus.health.healthStatus shouldBe ComponentHealthStatus.UNHEALTHY
+                    statusManager.overallStatus.health.details[EnvironmentChecker.COMPONENT_ID]
+                        ?.detail shouldBe "ChromeDriver failed to start after 2 attempts"
+                }
+
+                should("succeed on retry after initial failure") {
+                    val statusManager = JibriStatusManager()
+                    var callCount = 0
+                    val checker = EnvironmentChecker(statusManager) {
+                        callCount++
+                        if (callCount == 1) {
+                            throw RuntimeException("First attempt fails")
+                        }
+                    }
+
+                    checker.validate(maxAttempts = 3, retryDelayMs = 0)
+
+                    callCount shouldBe 2
+                    statusManager.overallStatus.health.healthStatus shouldBe ComponentHealthStatus.HEALTHY
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Jibri was broadcasting `IDLE+HEALTHY` to XMPP MUCs immediately on startup before ChromeDriver was validated, allowing Jicofo to dispatch requests that would fail during ChromeDriver initialization
- Adds an `EnvironmentChecker` that registers as `UNHEALTHY` at construction, then probes ChromeDriver in the background — Jibri only becomes `HEALTHY` (eligible for dispatch) after the probe succeeds
- Retry defaults (6 attempts, 10s delay) accommodate post-reboot delays where Xvfb/Chrome may not be immediately available
- Configurable via `jibri.chrome.startup-check`, `startup-check-max-attempts`, and `startup-check-retry-delay`

## Test plan

- [x] Unit tests for `EnvironmentChecker` (initial UNHEALTHY registration, successful transition, failure persistence, retry-then-succeed)
- [x] Full `mvn verify` passes (145 tests, 0 failures, ktlint clean)
- [ ] Deploy to a test Jibri and verify:
  - Initial XMPP presence shows `IDLE + UNHEALTHY`
  - After probe succeeds (~seconds), presence updates to `IDLE + HEALTHY`
  - HTTP `/jibri/api/v1.0/health` reflects the same transitions
  - Health check script does not trigger shutdown during normal startup window
- [ ] Verify `startup-check = false` preserves old behavior (immediate `IDLE + HEALTHY`)