### PR TITLE
feat: Handle *6 DTMF command in SIP gateway

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -280,30 +280,45 @@ class JibriSelenium(
     fun sendPresence(): Boolean = CallPage(chromeDriver).sendPresence()
 
     fun handleDtmfStar6() {
-        logger.info("Handling *6 DTMF command")
+        logger.info("Handling *6 DTMF command (audio toggle)")
         val callPage = CallPage(chromeDriver)
         if (callPage.isVisitor()) {
             logger.info("In visitor mode, toggling raise hand")
             callPage.raiseHand()
         } else if (!callPage.isLocalAudioMuted()) {
-            logger.info("Currently unmuted, muting audio")
-            val audioResult = callPage.toggleAudioMute()
-            logger.info("toggleAudioMute result: $audioResult")
+            logger.info("Currently audio unmuted, muting audio")
+            val result = callPage.toggleAudioMute()
+            logger.info("toggleAudioMute result: $result")
         } else {
             val audioForceMuted = callPage.isAudioForceMuted()
-            val videoForceMuted = callPage.isVideoForceMuted()
-            if (audioForceMuted && videoForceMuted) {
-                logger.info("Both audio and video force muted by AV moderation, raising hand to request unmute")
+            if (audioForceMuted) {
+                logger.info("Audio force muted by AV moderation, raising hand to request unmute")
                 callPage.raiseHand()
             } else {
-                if (!audioForceMuted) {
-                    val audioResult = callPage.toggleAudioMute()
-                    logger.info("toggleAudioMute result: $audioResult")
-                }
-                if (!videoForceMuted) {
-                    val videoResult = callPage.toggleVideoMute()
-                    logger.info("toggleVideoMute result: $videoResult")
-                }
+                val result = callPage.toggleAudioMute()
+                logger.info("toggleAudioMute result: $result")
+            }
+        }
+    }
+
+    fun handleDtmfStar7() {
+        logger.info("Handling *7 DTMF command (video toggle)")
+        val callPage = CallPage(chromeDriver)
+        if (callPage.isVisitor()) {
+            logger.info("In visitor mode, toggling raise hand")
+            callPage.raiseHand()
+        } else if (!callPage.isLocalVideoMuted()) {
+            logger.info("Currently video unmuted, muting video")
+            val result = callPage.toggleVideoMute()
+            logger.info("toggleVideoMute result: $result")
+        } else {
+            val videoForceMuted = callPage.isVideoForceMuted()
+            if (videoForceMuted) {
+                logger.info("Video force muted by AV moderation, raising hand to request unmute")
+                callPage.raiseHand()
+            } else {
+                val result = callPage.toggleVideoMute()
+                logger.info("toggleVideoMute result: $result")
             }
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -279,6 +279,35 @@ class JibriSelenium(
 
     fun sendPresence(): Boolean = CallPage(chromeDriver).sendPresence()
 
+    fun handleDtmfStar6() {
+        logger.info("Handling *6 DTMF command")
+        val callPage = CallPage(chromeDriver)
+        if (callPage.isVisitor()) {
+            logger.info("In visitor mode, toggling raise hand")
+            callPage.raiseHand()
+        } else if (!callPage.isLocalAudioMuted()) {
+            logger.info("Currently unmuted, muting audio")
+            val audioResult = callPage.toggleAudioMute()
+            logger.info("toggleAudioMute result: $audioResult")
+        } else {
+            val audioForceMuted = callPage.isAudioForceMuted()
+            val videoForceMuted = callPage.isVideoForceMuted()
+            if (audioForceMuted && videoForceMuted) {
+                logger.info("Both audio and video force muted by AV moderation, raising hand to request unmute")
+                callPage.raiseHand()
+            } else {
+                if (!audioForceMuted) {
+                    val audioResult = callPage.toggleAudioMute()
+                    logger.info("toggleAudioMute result: $audioResult")
+                }
+                if (!videoForceMuted) {
+                    val videoResult = callPage.toggleVideoMute()
+                    logger.info("toggleVideoMute result: $videoResult")
+                }
+            }
+        }
+    }
+
     /**
      * Join a web call with Selenium
      */

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -427,21 +427,69 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         return result as? Boolean ?: false
     }
 
-    fun toggleVideoMute(): Boolean {
-        val result = driver.executeScript(
+    // Toggles video mute and waits for the Redux store to confirm the state change.
+    // muteVideo() returns a Promise — firing it synchronously and returning immediately
+    // would not guarantee the toggle completed. Unmuting requires re-acquiring the camera
+    // device, which is slower (12s timeout) than muting/releasing it (5s). On timeout,
+    // extra state is returned to help diagnose why the change did not complete.
+    fun toggleVideoMute(): Any? {
+        driver.manage().timeouts().setScriptTimeout(20, TimeUnit.SECONDS)
+        return driver.executeAsyncScript(
             """
+            var done = arguments[0];
             try {
-                var isMuted = APP.store.getState()['features/base/media'].video.muted;
-                APP.conference.muteVideo(!isMuted);
-                return true;
+                var isMuted = APP.conference.isLocalVideoMuted();
+                var unsubscribe;
+                var timer;
+                var cleanup = function() { clearTimeout(timer); if (unsubscribe) unsubscribe(); };
+
+                var waitForChange = function(ms, timeoutMsg) {
+                    timer = setTimeout(function() {
+                        cleanup();
+                        var st = APP.store.getState();
+                        var vt = st['features/base/tracks'].filter(function(t) { return t.local && t.mediaType === 'video'; });
+                        done(timeoutMsg + ' mediaMuted=' + st['features/base/media'].video.muted +
+                             ' videoTracks=' + vt.length + ' hasJitsiTrack=' + vt.some(function(t) { return !!t.jitsiTrack; }));
+                    }, ms);
+                    unsubscribe = APP.store.subscribe(function() {
+                        var nowMuted = APP.conference.isLocalVideoMuted();
+                        if (nowMuted !== isMuted) {
+                            cleanup();
+                            done('ok wasMuted=' + isMuted + ' nowMuted=' + nowMuted);
+                        }
+                    });
+                };
+
+                if (!isMuted) {
+                    // Prefer muting via the track directly so the Promise rejection is catchable.
+                    // Fall back to a Redux dispatch when no track is present yet.
+                    var localVideo = APP.store.getState()['features/base/tracks']
+                        .find(function(t) { return t.local && t.mediaType === 'video' && t.jitsiTrack; });
+                    if (localVideo) {
+                        waitForChange(5000, 'timeout-muting');
+                        localVideo.jitsiTrack.mute().catch(function(e) { cleanup(); done('error-mute: ' + e); });
+                    } else {
+                        waitForChange(5000, 'timeout-mute-no-track');
+                        APP.store.dispatch({ type: 'SET_VIDEO_MUTED', muted: true });
+                    }
+                } else {
+                    // ensureTrack tells Jitsi to re-acquire the camera if no track exists yet.
+                    waitForChange(12000, 'timeout-unmuting');
+                    APP.store.dispatch({ type: 'SET_VIDEO_MUTED', muted: false, ensureTrack: true });
+                }
             } catch (e) {
-                return e.message;
+                done('error: ' + e.message);
             }
             """.trimMargin()
         )
-        return result is Boolean && result
     }
 
+    // Toggles audio mute and waits for the Redux store to confirm the state change.
+    // Audio track operations (especially unmuting/re-acquiring the microphone) are async —
+    // dispatching and returning immediately would not guarantee the toggle completed.
+    // Unmuting has a longer timeout (12s) than muting (5s) because re-acquiring a device
+    // is slower than releasing it. On timeout, extra state is returned to help diagnose
+    // why the change did not complete.
     fun toggleAudioMute(): Any? {
         driver.manage().timeouts().setScriptTimeout(20, TimeUnit.SECONDS)
         return driver.executeAsyncScript(
@@ -471,6 +519,8 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
                 };
 
                 if (!isMuted) {
+                    // Prefer muting via the track directly so the Promise rejection is catchable.
+                    // Fall back to a Redux dispatch when no track is present yet.
                     var localAudio = APP.store.getState()['features/base/tracks']
                         .find(function(t) { return t.local && t.mediaType === 'audio' && t.jitsiTrack; });
                     if (localAudio) {
@@ -481,6 +531,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
                         APP.store.dispatch({ type: 'SET_AUDIO_MUTED', muted: true });
                     }
                 } else {
+                    // ensureTrack tells Jitsi to re-acquire the microphone if no track exists yet.
                     waitForChange(12000, 'timeout-unmuting');
                     APP.store.dispatch({ type: 'SET_AUDIO_MUTED', muted: false, ensureTrack: true });
                 }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -389,6 +389,19 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         return result as? Boolean ?: true
     }
 
+    fun isLocalVideoMuted(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                return APP.conference.isLocalVideoMuted();
+            } catch (e) {
+                return true;
+            }
+            """.trimMargin()
+        )
+        return result as? Boolean ?: true
+    }
+
     /** Returns true if AV moderation is enabled for audio and the local participant is not approved to unmute. */
     fun isAudioForceMuted(): Boolean {
         val result = driver.executeScript(

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -23,6 +23,7 @@ import org.openqa.selenium.TimeoutException
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.support.PageFactory
 import org.openqa.selenium.support.ui.WebDriverWait
+import java.util.concurrent.TimeUnit
 import kotlin.time.measureTimedValue
 
 /**
@@ -360,6 +361,153 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
                 0
             }
         }
+    }
+
+    fun isVisitor(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                return APP.store.getState()['features/visitors']?.iAmVisitor === true;
+            } catch (e) {
+                return false;
+            }
+            """.trimMargin()
+        )
+        return result as? Boolean ?: false
+    }
+
+    fun isLocalAudioMuted(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                return APP.conference.isLocalAudioMuted();
+            } catch (e) {
+                return true;
+            }
+            """.trimMargin()
+        )
+        return result as? Boolean ?: true
+    }
+
+    /** Returns true if AV moderation is enabled for audio and the local participant is not approved to unmute. */
+    fun isAudioForceMuted(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                var state = APP.store.getState();
+                var avMod = state['features/av-moderation'];
+                if (!avMod || !avMod.audioModerationEnabled) return false;
+                var local = state['features/base/participants']?.local;
+                if (local && local.role === 'moderator') return false;
+                return avMod.audioUnmuteApproved !== true;
+            } catch (e) {
+                return false;
+            }
+            """.trimMargin()
+        )
+        return result as? Boolean ?: false
+    }
+
+    /** Returns true if AV moderation is enabled for video and the local participant is not approved to unmute. */
+    fun isVideoForceMuted(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                var state = APP.store.getState();
+                var avMod = state['features/av-moderation'];
+                if (!avMod || !avMod.videoModerationEnabled) return false;
+                var local = state['features/base/participants']?.local;
+                if (local && local.role === 'moderator') return false;
+                return avMod.videoUnmuteApproved !== true;
+            } catch (e) {
+                return false;
+            }
+            """.trimMargin()
+        )
+        return result as? Boolean ?: false
+    }
+
+    fun toggleVideoMute(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                var isMuted = APP.store.getState()['features/base/media'].video.muted;
+                APP.conference.muteVideo(!isMuted);
+                return true;
+            } catch (e) {
+                return e.message;
+            }
+            """.trimMargin()
+        )
+        return result is Boolean && result
+    }
+
+    fun toggleAudioMute(): Any? {
+        driver.manage().timeouts().setScriptTimeout(20, TimeUnit.SECONDS)
+        return driver.executeAsyncScript(
+            """
+            var done = arguments[0];
+            try {
+                var isMuted = APP.conference.isLocalAudioMuted();
+                var unsubscribe;
+                var timer;
+                var cleanup = function() { clearTimeout(timer); if (unsubscribe) unsubscribe(); };
+
+                var waitForChange = function(ms, timeoutMsg) {
+                    timer = setTimeout(function() {
+                        cleanup();
+                        var st = APP.store.getState();
+                        var at = st['features/base/tracks'].filter(function(t) { return t.local && t.mediaType === 'audio'; });
+                        done(timeoutMsg + ' mediaMuted=' + st['features/base/media'].audio.muted +
+                             ' audioTracks=' + at.length + ' hasJitsiTrack=' + at.some(function(t) { return !!t.jitsiTrack; }));
+                    }, ms);
+                    unsubscribe = APP.store.subscribe(function() {
+                        var nowMuted = APP.conference.isLocalAudioMuted();
+                        if (nowMuted !== isMuted) {
+                            cleanup();
+                            done('ok wasMuted=' + isMuted + ' nowMuted=' + nowMuted);
+                        }
+                    });
+                };
+
+                if (!isMuted) {
+                    var localAudio = APP.store.getState()['features/base/tracks']
+                        .find(function(t) { return t.local && t.mediaType === 'audio' && t.jitsiTrack; });
+                    if (localAudio) {
+                        waitForChange(5000, 'timeout-muting');
+                        localAudio.jitsiTrack.mute().catch(function(e) { cleanup(); done('error-mute: ' + e); });
+                    } else {
+                        waitForChange(5000, 'timeout-mute-no-track');
+                        APP.store.dispatch({ type: 'SET_AUDIO_MUTED', muted: true });
+                    }
+                } else {
+                    waitForChange(12000, 'timeout-unmuting');
+                    APP.store.dispatch({ type: 'SET_AUDIO_MUTED', muted: false, ensureTrack: true });
+                }
+            } catch (e) {
+                done('error: ' + e.message);
+            }
+            """.trimMargin()
+        )
+    }
+
+    fun raiseHand(): Boolean {
+        val result = driver.executeScript(
+            """
+            try {
+                const local = APP.store.getState()['features/base/participants']?.local;
+                const isRaised = local && local.raisedHandTimestamp > 0;
+                APP.store.dispatch({
+                    type: 'LOCAL_PARTICIPANT_RAISE_HAND',
+                    raisedHandTimestamp: isRaised ? 0 : Date.now()
+                });
+                return true;
+            } catch (e) {
+                return e.message;
+            }
+            """.trimMargin()
+        )
+        return result is Boolean && result
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -97,7 +97,13 @@ class SipGatewayJibriService(
      */
     private val pjsuaClient = pjsuaClient ?: PjsuaClient(
         logger,
-        PjsuaClientParams(sipGatewayServiceParams.sipClientParams)
+        PjsuaClientParams(sipGatewayServiceParams.sipClientParams),
+        onDtmfCommand = { command ->
+            if (command == "*6") {
+                logger.info("Received *6 DTMF command from pjsua")
+                this.jibriSelenium.handleDtmfStar6()
+            }
+        }
     )
 
     /**

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -99,9 +99,15 @@ class SipGatewayJibriService(
         logger,
         PjsuaClientParams(sipGatewayServiceParams.sipClientParams),
         onDtmfCommand = { command ->
-            if (command == "*6") {
-                logger.info("Received *6 DTMF command from pjsua")
-                this.jibriSelenium.handleDtmfStar6()
+            when (command) {
+                "*6" -> {
+                    logger.info("Received *6 DTMF command from pjsua")
+                    this.jibriSelenium.handleDtmfStar6()
+                }
+                "*7" -> {
+                    logger.info("Received *7 DTMF command from pjsua")
+                    this.jibriSelenium.handleDtmfStar7()
+                }
             }
         }
     )

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -27,6 +27,7 @@ import org.jitsi.jibri.sipgateway.pjsua.util.RemoteSipClientBusy
 import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.util.JibriSubprocess
 import org.jitsi.jibri.util.ProcessExited
+import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
@@ -45,7 +46,6 @@ data class PjsuaClientParams(
 
 private const val PJSUA_SCRIPT_FILE_LOCATION = "/opt/jitsi/jibri/pjsua.sh"
 private const val X_DISPLAY = ":1"
-private const val DTMF_FIFO_PATH = "/tmp/jibri_pjsua_dtmf"
 
 class PjsuaClient(
     parentLogger: Logger,
@@ -56,6 +56,9 @@ class PjsuaClient(
     private val pjsua: JibriSubprocess = JibriSubprocess(logger, "pjsua")
     private val sipOutboundPrefix: String? by optionalconfig(
         "jibri.sip.outbound-prefix".from(Config.configSource)
+    )
+    private val dtmfFifoPath: String by config(
+        "jibri.sip.dtmf-fifo-path".from(Config.configSource)
     )
     private var dtmfReaderThread: Thread? = null
 
@@ -149,10 +152,10 @@ class PjsuaClient(
 
     private fun createDtmfFifo() {
         try {
-            Files.deleteIfExists(Paths.get(DTMF_FIFO_PATH))
-            val process = Runtime.getRuntime().exec(arrayOf("mkfifo", DTMF_FIFO_PATH))
+            Files.deleteIfExists(Paths.get(dtmfFifoPath))
+            val process = Runtime.getRuntime().exec(arrayOf("mkfifo", dtmfFifoPath))
             process.waitFor()
-            logger.info("Created DTMF FIFO at $DTMF_FIFO_PATH")
+            logger.info("Created DTMF FIFO at $dtmfFifoPath")
         } catch (e: Exception) {
             logger.error("Failed to create DTMF FIFO", e)
         }
@@ -162,7 +165,7 @@ class PjsuaClient(
         dtmfReaderThread = Thread {
             try {
                 logger.info("DTMF FIFO reader waiting for pjsua to connect")
-                FileInputStream(File(DTMF_FIFO_PATH)).use { fis ->
+                FileInputStream(File(dtmfFifoPath)).use { fis ->
                     BufferedReader(InputStreamReader(fis)).use { reader ->
                         var line = reader.readLine()
                         while (line != null) {
@@ -190,7 +193,7 @@ class PjsuaClient(
     }
 
     private fun stopDtmfFifoReader() {
-        val fifoFile = File(DTMF_FIFO_PATH)
+        val fifoFile = File(dtmfFifoPath)
         if (!fifoFile.exists()) return
 
         // Open the write end to unblock dtmfReaderThread if it's blocking on open()
@@ -207,7 +210,7 @@ class PjsuaClient(
         unblockThread.join(2000)
 
         try {
-            Files.deleteIfExists(Paths.get(DTMF_FIFO_PATH))
+            Files.deleteIfExists(Paths.get(dtmfFifoPath))
         } catch (e: Exception) {}
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -33,8 +33,6 @@ import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
@@ -42,6 +40,8 @@ import java.io.FileOutputStream
 import java.io.InputStreamReader
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 data class PjsuaClientParams(
     val sipClientParams: SipClientParams
@@ -202,8 +202,12 @@ class PjsuaClient(
             } catch (e: Exception) {}
         }
 
-        try { dtmfReaderTask?.get(2000, TimeUnit.MILLISECONDS) } catch (e: Exception) {}
-        try { unblockTask.get(2000, TimeUnit.MILLISECONDS) } catch (e: Exception) {}
+        try {
+            dtmfReaderTask?.get(2000, TimeUnit.MILLISECONDS)
+        } catch (e: Exception) {}
+        try {
+            unblockTask.get(2000, TimeUnit.MILLISECONDS)
+        } catch (e: Exception) {}
 
         try {
             Files.deleteIfExists(Paths.get(dtmfFifoPath))

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -31,6 +31,13 @@ import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Paths
 
 data class PjsuaClientParams(
     val sipClientParams: SipClientParams
@@ -38,16 +45,19 @@ data class PjsuaClientParams(
 
 private const val PJSUA_SCRIPT_FILE_LOCATION = "/opt/jitsi/jibri/pjsua.sh"
 private const val X_DISPLAY = ":1"
+private const val DTMF_FIFO_PATH = "/tmp/jibri_pjsua_dtmf"
 
 class PjsuaClient(
     parentLogger: Logger,
-    private val pjsuaClientParams: PjsuaClientParams
+    private val pjsuaClientParams: PjsuaClientParams,
+    private val onDtmfCommand: ((String) -> Unit)? = null
 ) : SipClient() {
     private val logger = createChildLogger(parentLogger)
     private val pjsua: JibriSubprocess = JibriSubprocess(logger, "pjsua")
     private val sipOutboundPrefix: String? by optionalconfig(
         "jibri.sip.outbound-prefix".from(Config.configSource)
     )
+    private var dtmfReaderThread: Thread? = null
 
     companion object {
         const val COMPONENT_ID = "Pjsua"
@@ -74,6 +84,11 @@ class PjsuaClient(
     }
 
     override fun start() {
+        if (onDtmfCommand != null) {
+            createDtmfFifo()
+            startDtmfFifoReader()
+        }
+
         val command = mutableListOf(
             PJSUA_SCRIPT_FILE_LOCATION
         )
@@ -132,5 +147,67 @@ class PjsuaClient(
         pjsua.launch(command, mapOf("DISPLAY" to X_DISPLAY))
     }
 
-    override fun stop() = pjsua.stop()
+    private fun createDtmfFifo() {
+        try {
+            Files.deleteIfExists(Paths.get(DTMF_FIFO_PATH))
+            val process = Runtime.getRuntime().exec(arrayOf("mkfifo", DTMF_FIFO_PATH))
+            process.waitFor()
+            logger.info("Created DTMF FIFO at $DTMF_FIFO_PATH")
+        } catch (e: Exception) {
+            logger.error("Failed to create DTMF FIFO", e)
+        }
+    }
+
+    private fun startDtmfFifoReader() {
+        dtmfReaderThread = Thread {
+            try {
+                logger.info("DTMF FIFO reader waiting for pjsua to connect")
+                FileInputStream(File(DTMF_FIFO_PATH)).use { fis ->
+                    BufferedReader(InputStreamReader(fis)).use { reader ->
+                        var line = reader.readLine()
+                        while (line != null) {
+                            if (line.startsWith("DTMF_COMMAND:")) {
+                                onDtmfCommand?.invoke(line.removePrefix("DTMF_COMMAND:"))
+                            }
+                            line = reader.readLine()
+                        }
+                    }
+                }
+                logger.info("DTMF FIFO reader exited (EOF)")
+            } catch (e: Exception) {
+                logger.info("DTMF FIFO reader exited: ${e.message}")
+            }
+        }.also {
+            it.isDaemon = true
+            it.name = "dtmf-fifo-reader"
+            it.start()
+        }
+    }
+
+    override fun stop() {
+        pjsua.stop()
+        stopDtmfFifoReader()
+    }
+
+    private fun stopDtmfFifoReader() {
+        val fifoFile = File(DTMF_FIFO_PATH)
+        if (!fifoFile.exists()) return
+
+        // Open the write end to unblock dtmfReaderThread if it's blocking on open()
+        val unblockThread = Thread {
+            try {
+                FileOutputStream(fifoFile).close()
+            } catch (e: Exception) {}
+        }.also {
+            it.isDaemon = true
+            it.start()
+        }
+
+        dtmfReaderThread?.join(2000)
+        unblockThread.join(2000)
+
+        try {
+            Files.deleteIfExists(Paths.get(DTMF_FIFO_PATH))
+        } catch (e: Exception) {}
+    }
 }

--- a/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/sipgateway/pjsua/PjsuaClient.kt
@@ -27,11 +27,14 @@ import org.jitsi.jibri.sipgateway.pjsua.util.RemoteSipClientBusy
 import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.util.JibriSubprocess
 import org.jitsi.jibri.util.ProcessExited
+import org.jitsi.jibri.util.TaskPools
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
@@ -60,7 +63,7 @@ class PjsuaClient(
     private val dtmfFifoPath: String by config(
         "jibri.sip.dtmf-fifo-path".from(Config.configSource)
     )
-    private var dtmfReaderThread: Thread? = null
+    private var dtmfReaderTask: Future<*>? = null
 
     companion object {
         const val COMPONENT_ID = "Pjsua"
@@ -162,7 +165,7 @@ class PjsuaClient(
     }
 
     private fun startDtmfFifoReader() {
-        dtmfReaderThread = Thread {
+        dtmfReaderTask = TaskPools.ioPool.submit {
             try {
                 logger.info("DTMF FIFO reader waiting for pjsua to connect")
                 FileInputStream(File(dtmfFifoPath)).use { fis ->
@@ -180,10 +183,6 @@ class PjsuaClient(
             } catch (e: Exception) {
                 logger.info("DTMF FIFO reader exited: ${e.message}")
             }
-        }.also {
-            it.isDaemon = true
-            it.name = "dtmf-fifo-reader"
-            it.start()
         }
     }
 
@@ -196,18 +195,15 @@ class PjsuaClient(
         val fifoFile = File(dtmfFifoPath)
         if (!fifoFile.exists()) return
 
-        // Open the write end to unblock dtmfReaderThread if it's blocking on open()
-        val unblockThread = Thread {
+        // Open the write end to unblock the reader task if it's blocking on open()
+        val unblockTask = TaskPools.ioPool.submit {
             try {
                 FileOutputStream(fifoFile).close()
             } catch (e: Exception) {}
-        }.also {
-            it.isDaemon = true
-            it.start()
         }
 
-        dtmfReaderThread?.join(2000)
-        unblockThread.join(2000)
+        try { dtmfReaderTask?.get(2000, TimeUnit.MILLISECONDS) } catch (e: Exception) {}
+        try { unblockTask.get(2000, TimeUnit.MILLISECONDS) } catch (e: Exception) {}
 
         try {
             Files.deleteIfExists(Paths.get(dtmfFifoPath))

--- a/src/main/kotlin/org/jitsi/jibri/util/JibriSubprocess.kt
+++ b/src/main/kotlin/org/jitsi/jibri/util/JibriSubprocess.kt
@@ -18,7 +18,10 @@ package org.jitsi.jibri.util
 
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import java.io.BufferedReader
+import java.io.InputStreamReader
 import java.time.Duration
+import java.util.concurrent.Callable
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -27,6 +30,7 @@ class JibriSubprocess(
     parentLogger: Logger,
     private val name: String,
     private val processOutputLogger: Logger? = null,
+    private val outputLineHandler: ((String) -> Unit)? = null,
     private val processFactory: ProcessFactory = ProcessFactory(),
     processStatePublisherProvider: ((ProcessWrapper) -> ProcessStatePublisher)? = null
 ) : StatusPublisher<ProcessState>() {
@@ -48,8 +52,18 @@ class JibriSubprocess(
                 it.start()
                 processStatePublisher = processStatePublisherProvider(it)
                 processStatePublisher!!.addStatusHandler(this::publishStatus)
-                if (processOutputLogger != null) {
-                    processLoggerTask = LoggingUtils.logOutputOfProcess(it, processOutputLogger)
+                if (processOutputLogger != null || outputLineHandler != null) {
+                    processLoggerTask = TaskPools.ioPool.submit(
+                        Callable<Boolean> {
+                            val reader = BufferedReader(InputStreamReader(it.getOutput()))
+                            while (true) {
+                                val line = reader.readLine() ?: break
+                                processOutputLogger?.info(line)
+                                outputLineHandler?.invoke(line)
+                            }
+                            return@Callable true
+                        }
+                    )
                 }
             } ?: run {
                 throw Exception("Process was null")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -34,6 +34,7 @@ jibri {
   sip {
     // The routing rule for the outbound scenario in VoxImplant is based on this prefix
     outbound-prefix = "out_"
+    dtmf-fifo-path = "/tmp/jibri_pjsua_dtmf"
   }
   // These options control how Jibri generates the ffmpeg command for recording or streaming. Most options are internal
   // to this config file, meaning that they are not used directly by the jibri code, which just uses the 4

--- a/src/test/kotlin/org/jitsi/jibri/util/JibriSubprocessTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/util/JibriSubprocessTest.kt
@@ -41,7 +41,15 @@ internal class JibriSubprocessTest : ShouldSpec() {
     private val parentLogger: Logger = mockk(relaxed = true)
 
     @Suppress("MoveLambdaOutsideParentheses")
-    private val subprocess = JibriSubprocess(parentLogger, "name", mockk(), processFactory, { processStatePublisher })
+    private val subprocess = JibriSubprocess(
+        parentLogger,
+        "name",
+        mockk(),
+        processFactory = processFactory,
+        processStatePublisherProvider = {
+            processStatePublisher
+        }
+    )
     private val processStateHandler = slot<(ProcessState) -> Unit>()
     private val executorStateUpdates = mutableListOf<ProcessState>()
 


### PR DESCRIPTION
When a SIP caller presses *6, jibri now detects it via a named FIFO (/tmp/jibri_pjsua_dtmf) written to by pjsua and acts in the Jitsi Meet conference:

- Visitor mode: toggle raise hand
- Currently unmuted: mute audio only
- Currently muted, both audio+video blocked by AV moderation: raise hand
- Currently muted, audio or video allowed: unmute whichever is permitted

Also logs the full visited URL (including fragment params) on page load.