### PR TITLE
fix: Security fixes — logging, TLS, Jackson, chromedriver log path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.19.4</jackson.version>
         <junit.version>5.10.0</junit.version>
         <kotest.version>5.7.2</kotest.version>
         <mockk.version>1.13.8</mockk.version>

--- a/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
+++ b/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
@@ -125,7 +125,10 @@ class JibriManager : StatusPublisher<Any>() {
         serviceStatusHandler: JibriServiceStatusHandler? = null
     ) {
         throwIfBusy(RecordingSinkType.FILE)
-        logger.info("Starting a file recording, sessionId=${fileRecordingRequestParams.sessionId}, call=${fileRecordingRequestParams.callParams}")
+        logger.info(
+            "Starting a file recording, sessionId=${fileRecordingRequestParams.sessionId}, " +
+                "call=${fileRecordingRequestParams.callParams}"
+        )
         val service = FileRecordingJibriService(
             FileRecordingParams(
                 fileRecordingRequestParams.callParams,

--- a/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
+++ b/src/main/kotlin/org/jitsi/jibri/JibriManager.kt
@@ -125,7 +125,7 @@ class JibriManager : StatusPublisher<Any>() {
         serviceStatusHandler: JibriServiceStatusHandler? = null
     ) {
         throwIfBusy(RecordingSinkType.FILE)
-        logger.info("Starting a file recording with params: $fileRecordingRequestParams")
+        logger.info("Starting a file recording, sessionId=${fileRecordingRequestParams.sessionId}, call=${fileRecordingRequestParams.callParams}")
         val service = FileRecordingJibriService(
             FileRecordingParams(
                 fileRecordingRequestParams.callParams,
@@ -149,7 +149,7 @@ class JibriManager : StatusPublisher<Any>() {
         environmentContext: EnvironmentContext? = null,
         serviceStatusHandler: JibriServiceStatusHandler? = null
     ) {
-        logger.info("Starting a stream with params: $serviceParams $streamingParams")
+        logger.info("Starting a stream, sessionId=${streamingParams.sessionId}, call=${streamingParams.callParams}")
         throwIfBusy(RecordingSinkType.STREAM)
         val service = StreamingJibriService(streamingParams)
         jibriMetrics.start(RecordingSinkType.STREAM)
@@ -163,7 +163,7 @@ class JibriManager : StatusPublisher<Any>() {
         environmentContext: EnvironmentContext? = null,
         serviceStatusHandler: JibriServiceStatusHandler? = null
     ) {
-        logger.info("Starting a SIP gateway with params: $serviceParams $sipGatewayServiceParams")
+        logger.info("Starting a SIP gateway, call=${sipGatewayServiceParams.callParams}")
         throwIfBusy(RecordingSinkType.GATEWAY)
         val service = SipGatewayJibriService(
             SipGatewayServiceParams(

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -146,7 +146,7 @@ class XmppApi(
         // Join all the MUCs we've been told to
         for (config in xmppConfigs) {
             for (host in config.xmppServerHosts) {
-                logger.info("Connecting to xmpp environment on $host with config $config")
+                logger.info("Connecting to xmpp environment '${config.name}' on $host")
                 val hostDetails: List<String> = host.split(":")
 
                 // We need to use the host as the ID because we'll only get one MUC client per 'ID' and

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
-import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.jitsi.jibri.logger
@@ -194,7 +194,7 @@ fun loadConfigFromFile(configFile: File): JibriConfig? {
             .readValue(configFile)
         logger.info("Successfully parsed legacy config")
         config
-    } catch (e: MissingKotlinParameterException) {
+    } catch (e: MismatchedInputException) {
         logger.error("A required config parameter was missing: ${e.originalMessage}")
         null
     } catch (e: UnrecognizedPropertyException) {

--- a/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
+++ b/src/main/kotlin/org/jitsi/jibri/config/JibriConfig.kt
@@ -192,7 +192,7 @@ fun loadConfigFromFile(configFile: File): JibriConfig? {
         val config: JibriConfig = jacksonObjectMapper()
             .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
             .readValue(configFile)
-        logger.info("Parsed legacy config:\n$config")
+        logger.info("Successfully parsed legacy config")
         config
     } catch (e: MissingKotlinParameterException) {
         logger.error("A required config parameter was missing: ${e.originalMessage}")

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -189,7 +189,7 @@ class JibriSelenium(
      * Set up default chrome driver options (using fake device, etc.)
      */
     init {
-        System.setProperty("webdriver.chrome.logfile", "/tmp/chromedriver.log")
+        System.setProperty("webdriver.chrome.logfile", "/var/log/jitsi/jibri/chromedriver.log")
         val chromeOptions = ChromeOptions()
         chromeOptions.addArguments(chromeOpts)
         chromeOptions.setExperimentalOption("w3c", false)

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -18,7 +18,6 @@ package org.jitsi.jibri.webhooks.v1
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.Apache
-import javax.net.ssl.SSLContext
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -44,6 +43,7 @@ import org.jitsi.jwt.RefreshingJwt
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.createLogger
 import java.util.concurrent.CopyOnWriteArraySet
+import javax.net.ssl.SSLContext
 
 /**
  * A client for notifying subscribers of Jibri events

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -18,6 +18,7 @@ package org.jitsi.jibri.webhooks.v1
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.Apache
+import javax.net.ssl.SSLContext
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -49,7 +50,11 @@ import java.util.concurrent.CopyOnWriteArraySet
  */
 class WebhookClient(
     private val jibriId: String,
-    client: HttpClient = HttpClient(Apache)
+    client: HttpClient = HttpClient(Apache) {
+        engine {
+            sslContext = SSLContext.getDefault()
+        }
+    }
 ) {
     private val logger = createLogger()
     private val webhookSubscribers: MutableSet<String> = CopyOnWriteArraySet()


### PR DESCRIPTION
## Summary

- Avoid logging full XMPP environment config (usernames/domains) at INFO in `XmppApi`
- Avoid logging full legacy config object (XMPP credential objects) at INFO in `JibriConfig`
- Avoid logging XMPP credentials and RTMP URL at INFO in `JibriManager` service start methods
- Explicitly configure TLS certificate validation (`SSLContext.getDefault()`) in `WebhookClient`
- Update Jackson from 2.9.5 (multiple known CVEs) to 2.19.4; replace deprecated `MissingKotlinParameterException` with `MismatchedInputException`
- Write chromedriver log to `/var/log/jitsi/jibri/` instead of world-writable `/tmp`

These are all best-practice, no known impact.