### PR TITLE
Update Selenium from 3.12.0 to 4.43.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>8.0-SNAPSHOT</version>
 
     <properties>
-        <selenium.version>3.12.0</selenium.version>
+        <selenium.version>4.43.0</selenium.version>
         <kotlin.version>1.9.10</kotlin.version>
         <exec.mainClass>org.jitsi.jibri.MainKt</exec.mainClass>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -38,13 +38,13 @@ import org.jitsi.metaconfig.from
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.openqa.selenium.TimeoutException
+import org.openqa.selenium.WebDriverException
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeDriverService
 import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.logging.LogType
 import org.openqa.selenium.logging.LoggingPreferences
-import org.openqa.selenium.remote.CapabilityType
-import org.openqa.selenium.remote.UnreachableBrowserException
+import java.io.File
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
@@ -189,19 +189,18 @@ class JibriSelenium(
      * Set up default chrome driver options (using fake device, etc.)
      */
     init {
-        System.setProperty("webdriver.chrome.logfile", "/tmp/chromedriver.log")
         val chromeOptions = ChromeOptions()
         chromeOptions.addArguments(chromeOpts)
-        chromeOptions.setExperimentalOption("w3c", false)
         chromeOptions.addArguments(jibriSeleniumOptions.extraChromeCommandLineFlags)
-        val chromeDriverService = ChromeDriverService.Builder().withEnvironment(
-            mapOf("DISPLAY" to jibriSeleniumOptions.display)
-        ).build()
+        val chromeDriverService = ChromeDriverService.Builder()
+            .withEnvironment(mapOf("DISPLAY" to jibriSeleniumOptions.display))
+            .withLogFile(File("/var/log/jitsi/jibri/chromedriver.log"))
+            .build()
         val logPrefs = LoggingPreferences()
         logPrefs.enable(LogType.DRIVER, Level.ALL)
-        chromeOptions.setCapability(CapabilityType.LOGGING_PREFS, logPrefs)
+        chromeOptions.setCapability("goog:loggingPrefs", logPrefs)
         chromeDriver = ChromeDriver(chromeDriverService, chromeOptions)
-        chromeDriver.manage().timeouts().pageLoadTimeout(60, TimeUnit.SECONDS)
+        chromeDriver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(60))
 
         stateMachine.onStateTransition(this::onSeleniumStateChange)
     }
@@ -251,7 +250,7 @@ class JibriSelenium(
                 // which will result in this Jibri being marked as unhealthy
                 logger.error("Javascript timed out, assuming chrome has hung", t)
                 transitionState(SeleniumEvent.ChromeHung)
-            } catch (t: UnreachableBrowserException) {
+            } catch (t: WebDriverException) {
                 if (!shuttingDown.get()) {
                     logger.error("Can't reach browser", t)
                     transitionState(SeleniumEvent.ChromeHung)

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -24,7 +24,6 @@ import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.support.PageFactory
 import org.openqa.selenium.support.ui.WebDriverWait
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 import kotlin.time.measureTimedValue
 
 /**
@@ -447,7 +446,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
     // device, which is slower (12s timeout) than muting/releasing it (5s). On timeout,
     // extra state is returned to help diagnose why the change did not complete.
     fun toggleVideoMute(): Any? {
-        driver.manage().timeouts().setScriptTimeout(20, TimeUnit.SECONDS)
+        driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(20))
         return driver.executeAsyncScript(
             """
             var done = arguments[0];
@@ -505,7 +504,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
     // is slower than releasing it. On timeout, extra state is returned to help diagnose
     // why the change did not complete.
     fun toggleAudioMute(): Any? {
-        driver.manage().timeouts().setScriptTimeout(20, TimeUnit.SECONDS)
+        driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(20))
         return driver.executeAsyncScript(
             """
             var done = arguments[0];

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -23,6 +23,7 @@ import org.openqa.selenium.TimeoutException
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.support.PageFactory
 import org.openqa.selenium.support.ui.WebDriverWait
+import java.time.Duration
 import kotlin.time.measureTimedValue
 
 /**
@@ -43,7 +44,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         }
         val (result, totalTime) = measureTimedValue {
             try {
-                WebDriverWait(driver, 30).until {
+                WebDriverWait(driver, Duration.ofSeconds(30)).until {
                     val result = driver.executeScript(
                         """
                         try {
@@ -418,7 +419,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
 
         // Let's wait till we are alone in the room
         // (give time for the js Promise to finish before quiting selenium)
-        WebDriverWait(driver, 2).until {
+        WebDriverWait(driver, Duration.ofSeconds(2)).until {
             getNumParticipants() == 1
         }
 


### PR DESCRIPTION
## Summary

Upgrades Selenium from 3.12.0 to 4.43.0. Breaking API changes addressed:

- Remove `setExperimentalOption("w3c", false)` — W3C is the default in Selenium 4
- `CapabilityType.LOGGING_PREFS` → `"goog:loggingPrefs"` for Chrome-specific capability
- Chromedriver log configured via `ChromeDriverService.Builder().withLogFile()` instead of system property
- `pageLoadTimeout(long, TimeUnit)` → `pageLoadTimeout(Duration)`
- `UnreachableBrowserException` removed; replaced with `WebDriverException`
- `WebDriverWait(driver, long)` → `WebDriverWait(driver, Duration)`