### PR TITLE
feat: Make HTTP API bind host configurable

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/Main.kt
+++ b/src/main/kotlin/org/jitsi/jibri/Main.kt
@@ -125,10 +125,10 @@ fun main(args: Array<String>) {
         cleanupAndExit(255)
     }
 
-    logger.info("Using port ${InternalHttpApi.port} for internal HTTP API")
+    logger.info("Using ${InternalHttpApi.host}:${InternalHttpApi.port} for internal HTTP API")
 
     with(InternalHttpApi(configChangedHandler, gracefulShutdownHandler, shutdownHandler)) {
-        embeddedServer(Jetty, port = InternalHttpApi.port) {
+        embeddedServer(Jetty, host = InternalHttpApi.host, port = InternalHttpApi.port) {
             internalApiModule()
         }.start()
     }
@@ -151,11 +151,11 @@ fun main(args: Array<String>) {
     )
     xmppApi.start()
 
-    logger.info("Using port ${HttpApi.port} for HTTP API")
+    logger.info("Using ${HttpApi.host}:${HttpApi.port} for HTTP API")
 
     // HttpApi
     with(HttpApi(jibriManager, jibriStatusManager, webhookClient)) {
-        embeddedServer(Jetty, port = HttpApi.port) {
+        embeddedServer(Jetty, host = HttpApi.host, port = HttpApi.port) {
             apiModule()
         }
     }.start()

--- a/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/HttpApi.kt
@@ -254,5 +254,8 @@ class HttpApi(
             "http_api_port".from(Config.commandLineArgs).softDeprecated("use jibri.api.http.external-api-port")
             "jibri.api.http.external-api-port".from(Config.configSource)
         }
+        val host: String by config {
+            "jibri.api.http.external-api-host".from(Config.configSource)
+        }
     }
 }

--- a/src/main/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/http/internal/InternalHttpApi.kt
@@ -81,6 +81,9 @@ class InternalHttpApi(
                 .from(Config.commandLineArgs).softDeprecated("use jibri.api.http.internal-api-port")
             "jibri.api.http.internal-api-port".from(Config.configSource)
         }
+        val host: String by config {
+            "jibri.api.http.internal-api-host".from(Config.configSource)
+        }
     }
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,7 +10,9 @@ jibri {
   api {
     http {
       external-api-port = 2222
+      external-api-host = "127.0.0.1"
       internal-api-port = 3333
+      internal-api-host = "127.0.0.1"
     }
     xmpp {
       // See example_xmpp_envs.conf for an example of what is expected here


### PR DESCRIPTION
Default to 127.0.0.1, configure via jibri.api.http.internal-api-host and jibri.api.http.external-api-host.
