### PR TITLE
feat: Bump to JVM 17, Kotlin 2.3.21, ktor 3.4.3, jicoco 1.1-170

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,19 +10,40 @@
 
     <properties>
         <selenium.version>4.43.0</selenium.version>
-        <kotlin.version>1.9.10</kotlin.version>
+        <kotlin.version>2.3.21</kotlin.version>
         <exec.mainClass>org.jitsi.jibri.MainKt</exec.mainClass>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
         <jackson.version>2.19.4</jackson.version>
         <junit.version>5.10.0</junit.version>
         <kotest.version>5.7.2</kotest.version>
         <mockk.version>1.13.8</mockk.version>
-        <ktor.version>3.0.0</ktor.version>
-        <jicoco.version>1.1-159-gf9c2712</jicoco.version>
+        <ktor.version>3.4.3</ktor.version>
+        <jicoco.version>1.1-170-g3f48c50</jicoco.version>
         <jitsi.utils.version>1.0-127-g6c65524</jitsi.utils.version>
+        <jetty.version>12.0.35</jetty.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Align all Jetty artifacts with the version used by jicoco. -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-bom</artifactId>
+                <version>${jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -124,7 +145,7 @@
         </dependency>
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-client-apache-jvm</artifactId>
+            <artifactId>ktor-client-apache5-jvm</artifactId>
             <version>${ktor.version}</version>
         </dependency>
         <dependency>
@@ -242,7 +263,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.10.0</version>
+            <version>1.14.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -298,6 +319,7 @@
                                 <arg>-Werror</arg>
                                 <arg>-opt-in=kotlin.ExperimentalStdlibApi</arg>
                                 <arg>-opt-in=kotlin.time.ExperimentalTime</arg>
+                                <arg>-Xannotation-default-target=param-property</arg>
                             </args>
                         </configuration>
                     </execution>

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -269,7 +269,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         return when (result) {
             is Number -> result.toInt()
             else -> {
-                logger.error("error running numRemoteParticipantsJigasi script: $result ${result::class.java}")
+                logger.error("error running numRemoteParticipantsJigasi script: $result ${result?.javaClass}")
                 0
             }
         }
@@ -291,7 +291,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         return when (result) {
             is Number -> result.toInt()
             else -> {
-                logger.error("error running numHiddenParticipants script: $result ${result::class.java}")
+                logger.error("error running numHiddenParticipants script: $result ${result?.javaClass}")
                 0
             }
         }
@@ -357,7 +357,7 @@ class CallPage(driver: RemoteWebDriver) : AbstractPageObject(driver) {
         return when (result) {
             is Number -> result.toInt()
             else -> {
-                logger.error("error running numRemoteParticipantsMuted script: $result ${result::class.java}")
+                logger.error("error running numRemoteParticipantsMuted script: $result ${result?.javaClass}")
                 0
             }
         }

--- a/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
+++ b/src/main/kotlin/org/jitsi/jibri/webhooks/v1/WebhookClient.kt
@@ -17,7 +17,7 @@
 package org.jitsi.jibri.webhooks.v1
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.apache.Apache
+import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -50,7 +50,7 @@ import javax.net.ssl.SSLContext
  */
 class WebhookClient(
     private val jibriId: String,
-    client: HttpClient = HttpClient(Apache) {
+    client: HttpClient = HttpClient(Apache5) {
         engine {
             sslContext = SSLContext.getDefault()
         }

--- a/src/test/kotlin/org/jitsi/jibri/api/http/HttpApiTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/api/http/HttpApiTest.kt
@@ -31,7 +31,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.ApplicationTestBuilder
-import io.ktor.server.testing.TestApplication
+import io.ktor.server.testing.runTestApplication
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -154,7 +154,7 @@ class HttpApiTest : ShouldSpec() {
         }
     }
     private suspend fun apiTest(block: suspend ApplicationTestBuilder.() -> Unit) {
-        testApplication {
+        runTestApplication {
             application {
                 with(api) {
                     apiModule()
@@ -163,13 +163,4 @@ class HttpApiTest : ShouldSpec() {
             block()
         }
     }
-}
-
-// Avoid runBlocking from Ktor [testApplication], for kotest.
-@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
-private suspend fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit) {
-    val builder = ApplicationTestBuilder().apply { block() }
-    val testApplication = TestApplication(builder)
-    testApplication.start()
-    testApplication.stop()
 }


### PR DESCRIPTION
Update build target to Java 17 along with the dependency upgrades it unblocks. ktor 3.4.3 brings in jetty 12, replacing the prior jetty 11 transitive from ktor 3.0.0; jetty is pinned to 12.0.35 via the jetty-bom / jetty-ee10-bom imports to align with jicoco. byte-buddy bumped to 1.14.6 (aligning with MockKs byte-buddy-agent) so MockK can subclass cleanly under JDK 17.

The Kotlin 2.x K2 compiler caught a latent NPE in CallPage error logging (result class literal where result was nullable). The Apache HTTP engine is deprecated in newer ktor, so WebhookClient migrates to Apache5, which shares the same SSLContext config. HttpApiTest drops a custom TestApplication workaround in favor of ktors now-public runTestApplication suspend function.

Added -Xannotation-default-target=param-property to opt into the Kotlin 2.4 default behavior for annotations on data-class constructor parameters, which is what Jackson needs anyway.