### PR TITLE
Apply rtcstats_enabled from Jibri invite to call URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-xmpp-extensions</artifactId>
-            <version>1.0-95-ge113e35</version>
+            <version>1.0-110-g00660c3</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -371,7 +371,10 @@ class XmppApi(
             jacksonObjectMapper().readValue<AppData>(startIq.appData)
         }
         val serviceParams = ServiceParams(xmppEnvironment.usageTimeoutMins, appData)
-        val callParams = CallParams(callUrlInfo)
+        val extraUrlParams = buildList {
+            startIq.rtcStatsEnabled?.let { add("config.analytics.rtcstatsEnabled=$it") }
+        }
+        val callParams = CallParams(callUrlInfo, extraUrlParams = extraUrlParams)
         logger.info("Parsed call url info: $callUrlInfo")
 
         when (startIq.mode()) {

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -79,7 +79,11 @@ data class CallParams(
      * Display name which when it is set, it is used by jibri when joining the web conference.
      * Note that this is currently only used in the sipgateway gateway scenario;
      */
-    val displayName: String = ""
+    val displayName: String = "",
+    /**
+     * Extra URL params to add when joining the call, on top of the service-specific defaults.
+     */
+    val extraUrlParams: List<String> = listOf()
 ) {
     override fun toString(): String {
         return if (passcode.isNullOrEmpty()) {

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
@@ -168,7 +168,9 @@ class FileRecordingJibriService(
             return
         }
         jibriSelenium.joinCall(
-            fileRecordingParams.callParams.callUrlInfo.copy(urlParams = RECORDING_URL_OPTIONS),
+            fileRecordingParams.callParams.callUrlInfo.copy(
+                urlParams = RECORDING_URL_OPTIONS + fileRecordingParams.callParams.extraUrlParams
+            ),
             fileRecordingParams.callLoginParams
         )
 

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -133,7 +133,9 @@ class SipGatewayJibriService(
      */
     override fun start() {
         jibriSelenium.joinCall(
-            sipGatewayServiceParams.callParams.callUrlInfo.copy(urlParams = SIP_GW_URL_OPTIONS),
+            sipGatewayServiceParams.callParams.callUrlInfo.copy(
+                urlParams = SIP_GW_URL_OPTIONS + sipGatewayServiceParams.callParams.extraUrlParams
+            ),
             sipGatewayServiceParams.callLoginParams,
             sipGatewayServiceParams.callParams.passcode,
             unmute = true

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -105,7 +105,9 @@ class StreamingJibriService(
             return
         }
         jibriSelenium.joinCall(
-            streamingParams.callParams.callUrlInfo.copy(urlParams = RECORDING_URL_OPTIONS),
+            streamingParams.callParams.callUrlInfo.copy(
+                urlParams = RECORDING_URL_OPTIONS + streamingParams.callParams.extraUrlParams
+            ),
             streamingParams.callLoginParams
         )
 


### PR DESCRIPTION
Handle the `rtcstats_enabled` field from the Jibri start IQ by adding `config.analytics.rtcstatsEnabled=<value>` to the Jitsi Meet URL when launching the browser client.

- `CallParams` gains an `extraUrlParams` field merged with service-specific URL options
- `XmppApi` populates `extraUrlParams` from `startIq.rtcStatsEnabled`
- Applies to file recording, live streaming, and SIP gateway services

Depends on jitsi/jitsi-xmpp-extensions#138.