### PR TITLE
fix: Use getRoomsInfo() for number of participants

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -83,6 +83,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             val result = driver.executeScript(
                 "return window.jibriRecorderApi ? window.jibriRecorderApi.getNumberOfParticipants() : 1;"
             )
+            logger.debug("Number of participants: $result")
             (result as? Number)?.toInt() ?: 1
         } catch (t: Throwable) {
             logger.error("Error getting participant count: ${t.message}")

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -81,11 +81,9 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
     override fun getNumParticipants(): Int {
         return try {
             val result = driver.executeScript(
-                "return window.jibriPageState ? window.jibriPageState.getRemoteParticipantCount() + 1 : 1;"
+                "return window.jibriRecorderApi ? window.jibriRecorderApi.getNumberOfParticipants() : 1;"
             )
-            val count = (result as? Number)?.toInt() ?: 1
-            logger.debug("getNumParticipants: result=$result, count=$count")
-            count
+            (result as? Number)?.toInt() ?: 1
         } catch (t: Throwable) {
             logger.error("Error getting participant count: ${t.message}")
             1

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -80,13 +80,25 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun getNumParticipants(): Int {
         return try {
-            val result = driver.executeScript(
-                "return window.jibriRecorderApi ? window.jibriRecorderApi.getNumberOfParticipants() : 1;"
-            )
-            logger.debug("Number of participants: $result")
-            (result as? Number)?.toInt() ?: 1
+            driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(20))
+            val result = driver.executeAsyncScript(
+                """
+                const cb = arguments[arguments.length - 1];
+                if (!window.jibriRecorderApi) {
+                    cb(1);
+                    return;
+                }
+                window.jibriRecorderApi.getRoomsInfo().then(roomsData => {
+                    const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
+                    cb(mainRoom?.participants?.length || 1);
+                }).catch(() => cb(1));
+                """
+            ) as? Number
+            val count = result?.toInt() ?: 1
+            logger.debug("Number of participants: $count")
+            count
         } catch (t: Throwable) {
-            logger.error("Error getting participant count: ${t.message}")
+            logger.error("Error getting number of participants: ${t.message}")
             1
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -24,6 +24,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     init {
         PageFactory.initElements(driver, this)
+        driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(20))
     }
 
     override fun visit(url: CallUrlInfo): Boolean {
@@ -80,7 +81,6 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun getNumParticipants(): Int {
         return try {
-            driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(20))
             val result = driver.executeAsyncScript(
                 """
                 const cb = arguments[arguments.length - 1];

--- a/src/main/resources/recorder.html
+++ b/src/main/resources/recorder.html
@@ -75,27 +75,14 @@
 					window.jibriPageState = {
 						conferenceJoined: false,
 						apiError: null,
-						participantIds: new Set(),
-						getRemoteParticipantCount() {
-							return this.participantIds.size;
-						},
 					};
 
 					api.addListener("videoConferenceJoined", () => {
 						window.jibriPageState.conferenceJoined = true;
 					});
 
-					api.addListener("participantJoined", (p) => {
-						window.jibriPageState.participantIds.add(p.id);
-					});
-
-					api.addListener("participantLeft", (p) => {
-						window.jibriPageState.participantIds.delete(p.id);
-					});
-
 					api.addListener("videoConferenceLeft", () => {
 						window.jibriPageState.conferenceJoined = false;
-						window.jibriPageState.participantIds.clear();
 					});
 
 					api.addListener("errorOccurred", (error) => {

--- a/src/test/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPageTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPageTest.kt
@@ -81,19 +81,19 @@ internal class ExternalAPIPageTest : ShouldSpec() {
         }
 
         should("return participant count") {
-            every { driver.executeScript(any<String>()) } returns 3L
+            every { driver.executeAsyncScript(any<String>()) } returns 3L
 
             page.getNumParticipants() shouldBe 3
         }
 
         should("return true when only recorder present") {
-            every { driver.executeScript(any<String>()) } returns 1L
+            every { driver.executeAsyncScript(any<String>()) } returns 1L
 
             page.isCallEmpty() shouldBe true
         }
 
         should("return false when participants present") {
-            every { driver.executeScript(any<String>()) } returns 2L
+            every { driver.executeAsyncScript(any<String>()) } returns 2L
 
             page.isCallEmpty() shouldBe false
         }


### PR DESCRIPTION
This PR adds use of `getRoomsInfo()` in `ExternalAPIPage`, counting participants from the main room.