### PR TITLE
fix: fetch bitrates from iframe api

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -106,7 +106,27 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
     override fun isCallEmpty() = getNumParticipants() <= 1
 
     @Suppress("UNCHECKED_CAST")
-    override fun getBitrates(): Map<String, Any?> = mapOf()
+    override fun getBitrates(): Map<String, Any?> {
+        return try {
+            val result = driver.executeAsyncScript(
+                """
+                const cb = arguments[arguments.length - 1];
+                if (!window.jibriRecorderApi) {
+                    cb({});
+                    return;
+                }
+                window.jibriRecorderApi.getConnectionStats()
+                    .then(stats => cb(stats || {}))
+                    .catch(() => cb({}));
+                """
+            )
+            val stats = result as? Map<String, Any?> ?: mapOf()
+            stats["bitrate"] as? Map<String, Any?> ?: mapOf()
+        } catch (t: Throwable) {
+            logger.error("Error getting bitrates: ${t.message}")
+            mapOf()
+        }
+    }
 
     override fun injectParticipantTrackerScript(): Boolean = true
 


### PR DESCRIPTION
Implements `ExternalAPIPage.getBitrates()` by fetching bitrates using the IFrame API's `getConnectionStats()`. This enables the recorder to detect media.

Depends on: https://github.com/jitsi/jitsi-meet/pull/17594