### PR TITLE
fix: Restore credentials in recorder page's localStorage

### DIFF
--- a/src/main/resources/recorder.html
+++ b/src/main/resources/recorder.html
@@ -56,6 +56,17 @@
 				);
 
 				try {
+					if (config.appData?.localStorageContent) {
+						const decoded = decodeURIComponent(
+							config.appData.localStorageContent,
+						);
+						const localStorageContent = JSON.parse(decoded);
+						localStorage.setItem(
+							"jitsiLocalStorage",
+							localStorageContent,
+						);
+					}
+
 					const api = new JitsiMeetExternalAPI(domain, {
 						roomName: roomName,
 						parentNode: document.querySelector(


### PR DESCRIPTION
`recorder.html` stopped storing credentials in the page's localStorage, so Jibri joined and stayed visible.