### PR TITLE
feat: Implement ExternalAPIPage.isIceConnected

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -184,7 +184,28 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun numHiddenParticipants(): Int = 0
 
-    override fun isIceConnected(): Boolean = true
+    override fun isIceConnected(): Boolean {
+        return try {
+            val result = driver.executeAsyncScript(
+                """
+                const cb = arguments[arguments.length - 1];
+                if (!window.jibriRecorderApi) {
+                    cb(false);
+                    return;
+                }
+                window.jibriRecorderApi.getConnectionStats()
+                    .then(stats => cb(stats?.iceConnected === true))
+                    .catch(() => cb(false));
+                """
+            )
+            val iceConnected = result as? Boolean ?: false
+            logger.debug("ICE connected: $iceConnected")
+            iceConnected
+        } catch (t: Throwable) {
+            logger.error("Error while determining ICE connection status", t)
+            false
+        }
+    }
 
     override fun isLocalParticipantKicked(): Boolean = false
 

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -189,13 +189,17 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             val result = driver.executeAsyncScript(
                 """
                 const cb = arguments[arguments.length - 1];
-                if (!window.jibriRecorderApi) {
+                try {
+                    if (!window.jibriRecorderApi || typeof window.jibriRecorderApi.getConnectionStats !== 'function') {
+                        cb(false);
+                        return;
+                    }
+                    window.jibriRecorderApi.getConnectionStats()
+                        .then(stats => cb(stats?.iceConnected === true))
+                        .catch(() => cb(false));
+                } catch (e) {
                     cb(false);
-                    return;
                 }
-                window.jibriRecorderApi.getConnectionStats()
-                    .then(stats => cb(stats?.iceConnected === true))
-                    .catch(() => cb(false));
                 """
             )
             val iceConnected = result as? Boolean ?: false

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -185,30 +185,17 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
     override fun numHiddenParticipants(): Int = 0
 
     override fun isIceConnected(): Boolean {
-        return try {
-            val result = driver.executeAsyncScript(
-                """
-                const cb = arguments[arguments.length - 1];
-                try {
-                    if (!window.jibriRecorderApi || typeof window.jibriRecorderApi.getConnectionStats !== 'function') {
-                        cb(false);
-                        return;
-                    }
-                    window.jibriRecorderApi.getConnectionStats()
-                        .then(stats => cb(stats?.iceConnected === true))
-                        .catch(() => cb(false));
-                } catch (e) {
-                    cb(false);
-                }
-                """
-            )
-            val iceConnected = result as? Boolean ?: false
-            logger.debug("ICE connected: $iceConnected")
-            iceConnected
-        } catch (t: Throwable) {
-            logger.error("Error while determining ICE connection status", t)
-            false
-        }
+        val result = callRecorderApiAsync(
+            "getConnectionStats",
+            """
+            api.getConnectionStats()
+                .then(stats => cb(stats?.iceConnected === true))
+                .catch(() => cb(false));
+            """
+        )
+        val iceConnected = result as? Boolean ?: false
+        logger.debug("ICE connected: $iceConnected")
+        return iceConnected
     }
 
     override fun isLocalParticipantKicked(): Boolean = false


### PR DESCRIPTION
Implements `ExternalAPIPage.isIceConnected` from the `iceConnected` field returned by `getConnectionStats`.

Depends on: https://github.com/jitsi/jitsi-meet/pull/17620