### PR TITLE
feat: Add numRemoteParticipantsJigasi to ExternalAPIPage

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -180,7 +180,31 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun getParticipants(): List<Map<String, Any>> = listOf()
 
-    override fun numRemoteParticipantsJigasi(): Int = 0
+    override fun numRemoteParticipantsJigasi(): Int {
+        return try {
+            val result = driver.executeAsyncScript(
+                """
+                const cb = arguments[arguments.length - 1];
+                if (!window.jibriRecorderApi) {
+                    cb(0);
+                    return;
+                }
+                window.jibriRecorderApi.getRoomsInfo().then(roomsData => {
+                    const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
+                    const numJigasiParticipants = (mainRoom?.participants || []).filter(p => p?.isJigasi === true).length;
+                    cb(numJigasiParticipants);
+                }).catch(() => cb(0));
+                """
+            ) as? Number
+
+            val numJigasiParticipants = result?.toInt() ?: 0
+            logger.debug("Number of Jigasi participants: $numJigasiParticipants")
+            numJigasiParticipants
+        } catch (t: Throwable) {
+            logger.error("Error getting number of Jigasi participants: ${t.message}")
+            0
+        }
+    }
 
     override fun numHiddenParticipants(): Int = 0
 

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -201,7 +201,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             logger.debug("Number of Jigasi participants: $numJigasiParticipants")
             numJigasiParticipants
         } catch (t: Throwable) {
-            logger.error("Error getting number of Jigasi participants: ${t.message}")
+            logger.error("Error getting number of Jigasi participants", t)
             0
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -181,29 +181,19 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
     override fun getParticipants(): List<Map<String, Any>> = listOf()
 
     override fun numRemoteParticipantsJigasi(): Int {
-        return try {
-            val result = driver.executeAsyncScript(
-                """
-                const cb = arguments[arguments.length - 1];
-                if (!window.jibriRecorderApi) {
-                    cb(0);
-                    return;
-                }
-                window.jibriRecorderApi.getRoomsInfo().then(roomsData => {
-                    const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
-                    const numJigasiParticipants = (mainRoom?.participants || []).filter(p => p?.isJigasi === true).length;
-                    cb(numJigasiParticipants);
-                }).catch(() => cb(0));
-                """
-            ) as? Number
-
-            val numJigasiParticipants = result?.toInt() ?: 0
-            logger.debug("Number of Jigasi participants: $numJigasiParticipants")
-            numJigasiParticipants
-        } catch (t: Throwable) {
-            logger.error("Error getting number of Jigasi participants", t)
-            0
-        }
+        val result = callRecorderApiAsync(
+            "getRoomsInfo",
+            """
+            api.getRoomsInfo().then(roomsData => {
+                const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
+                const numJigasiParticipants = (mainRoom?.participants || []).filter(p => p?.isJigasi === true).length;
+                cb(numJigasiParticipants);
+            }).catch(() => cb(0));
+            """
+        ) as? Number
+        val numJigasiParticipants = result?.toInt() ?: 0
+        logger.debug("Number of Jigasi participants: $numJigasiParticipants")
+        return numJigasiParticipants
     }
 
     override fun numHiddenParticipants(): Int = 0

--- a/src/test/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPageTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPageTest.kt
@@ -97,5 +97,17 @@ internal class ExternalAPIPageTest : ShouldSpec() {
 
             page.isCallEmpty() shouldBe false
         }
+
+        should("return number of jigasi participants") {
+            every { driver.executeAsyncScript(any<String>()) } returns 2L
+
+            page.numRemoteParticipantsJigasi() shouldBe 2
+        }
+
+        should("return 0 jigasi participants when script fails") {
+            every { driver.executeAsyncScript(any<String>()) } throws RuntimeException("script error")
+
+            page.numRemoteParticipantsJigasi() shouldBe 0
+        }
     }
 }


### PR DESCRIPTION
Implements `ExternalAPIPage.numRemoteParticipantsJigasi()`, counting `isJigasi === true` entries from `getRoomsInfo()`

Depends on: https://github.com/jitsi/jitsi-meet/pull/17624