### PR TITLE
feat(external-api): Participant presence setting

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -290,6 +290,10 @@ class JibriSelenium(
 
     fun sendPresence(): Boolean = callPage.sendPresence()
 
+    fun setParticipantProperties(properties: Map<String, String>): Boolean = callPage.setParticipantProperties(
+        properties
+    )
+
     fun handleDtmfStar6() {
         logger.info("Handling *6 DTMF command (audio toggle)")
 

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/CallPage.kt
@@ -45,6 +45,10 @@ interface CallPage {
     fun raiseHand(): Boolean
     fun addToPresence(key: String, value: String): Boolean
     fun sendPresence(): Boolean
+    fun setParticipantProperties(properties: Map<String, String>): Boolean {
+        properties.forEach { (key, value) -> addToPresence(key, value) }
+        return sendPresence()
+    }
     fun leave(): Boolean
     fun getBitrates(): Map<String, Any?>
 

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -278,6 +278,4 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             false
         }
     }
-
-    override fun leave(): Boolean = true
 }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -274,7 +274,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             }
             result
         } catch (t: Throwable) {
-            logger.error("Error setting participant properties: ${t.message}")
+            logger.error("Error setting participant properties", t)
             false
         }
     }

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -232,7 +232,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun raiseHand(): Boolean = true
 
-    override fun addToPresence(key: String, value: String): Boolean = true
+    override fun addToPresence(key: String, value: String): Boolean = setParticipantProperties(mapOf(key to value))
 
     override fun sendPresence(): Boolean = true
 
@@ -257,4 +257,27 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             false
         }
     }
+    override fun setParticipantProperties(properties: Map<String, String>): Boolean {
+        return try {
+            val result = driver.executeScript(
+                """
+                if (!window.jibriRecorderApi) {
+                    return false;
+                }
+                window.jibriRecorderApi.executeCommand('setParticipantProperties', arguments[0]);
+                return true;
+                """,
+                properties
+            ) as? Boolean ?: false
+            if (!result) {
+                logger.warn("Could not set participant properties, External API not ready")
+            }
+            result
+        } catch (t: Throwable) {
+            logger.error("Error setting participant properties: ${t.message}")
+            false
+        }
+    }
+
+    override fun leave(): Boolean = true
 }

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/FileRecordingJibriService.kt
@@ -177,9 +177,12 @@ class FileRecordingJibriService(
         whenever(jibriSelenium).transitionsTo(ComponentState.Running) {
             logger.info("Selenium joined the call, starting the capturer")
             try {
-                jibriSelenium.addToPresence("session_id", fileRecordingParams.sessionId)
-                jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.FILE.toString())
-                jibriSelenium.sendPresence()
+                jibriSelenium.setParticipantProperties(
+                    mapOf(
+                        "session_id" to fileRecordingParams.sessionId,
+                        "mode" to JibriIq.RecordingMode.FILE.toString()
+                    )
+                )
                 capturer.start(sink)
             } catch (t: Throwable) {
                 logger.error("Error while setting fields in presence", t)

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -163,6 +163,7 @@ class SipGatewayJibriService(
             val sipAddress = sipGatewayServiceParams.sipClientParams.sipAddress.getSipAddress()
             val sipScheme = sipGatewayServiceParams.sipClientParams.sipAddress.getSipScheme()
             if (!jibriSelenium.setParticipantProperties(mapOf("sip_address" to "$sipScheme:$sipAddress"))) {
+                logger.error("Error while setting SIP address in presence")
                 publishStatus(ComponentState.Error(ErrorSettingPresenceFields))
             }
         } catch (t: Throwable) {

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriService.kt
@@ -162,8 +162,9 @@ class SipGatewayJibriService(
         try {
             val sipAddress = sipGatewayServiceParams.sipClientParams.sipAddress.getSipAddress()
             val sipScheme = sipGatewayServiceParams.sipClientParams.sipAddress.getSipScheme()
-            jibriSelenium.addToPresence("sip_address", "$sipScheme:$sipAddress")
-            jibriSelenium.sendPresence()
+            if (!jibriSelenium.setParticipantProperties(mapOf("sip_address" to "$sipScheme:$sipAddress"))) {
+                publishStatus(ComponentState.Error(ErrorSettingPresenceFields))
+            }
         } catch (t: Throwable) {
             logger.error("Error while setting fields in presence", t)
             publishStatus(ComponentState.Error(ErrorSettingPresenceFields))

--- a/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
+++ b/src/main/kotlin/org/jitsi/jibri/service/impl/StreamingJibriService.kt
@@ -114,14 +114,16 @@ class StreamingJibriService(
         whenever(jibriSelenium).transitionsTo(ComponentState.Running) {
             logger.info("Selenium joined the call, starting capturer")
             try {
-                jibriSelenium.addToPresence("session_id", streamingParams.sessionId)
-                jibriSelenium.addToPresence("mode", JibriIq.RecordingMode.STREAM.toString())
+                val properties = mutableMapOf(
+                    "session_id" to streamingParams.sessionId,
+                    "mode" to JibriIq.RecordingMode.STREAM.toString()
+                )
                 streamingParams.viewingUrl?.let { viewingUrl ->
-                    if (!jibriSelenium.addToPresence("live-stream-view-url", viewingUrl)) {
-                        logger.error("Error adding live stream url to presence")
-                    }
+                    properties["live-stream-view-url"] = viewingUrl
                 }
-                jibriSelenium.sendPresence()
+                if (!jibriSelenium.setParticipantProperties(properties)) {
+                    logger.error("Error setting presence properties")
+                }
                 capturer.start(sink)
             } catch (t: Throwable) {
                 logger.error("Error while setting fields in presence", t)

--- a/src/test/kotlin/org/jitsi/jibri/helpers/SeleniumMockHelper.kt
+++ b/src/test/kotlin/org/jitsi/jibri/helpers/SeleniumMockHelper.kt
@@ -20,6 +20,7 @@ class SeleniumMockHelper {
                 true
             }
         }
+        every { setParticipantProperties(any()) } returns true
     }
 
     fun startSuccessfully() {

--- a/src/test/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriServiceTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/service/impl/SipGatewayJibriServiceTest.kt
@@ -89,8 +89,11 @@ internal class SipGatewayJibriServiceTest : ShouldSpec() {
                     verify { pjsuaClientMockHelper.mock.start() }
                 }
                 should("add sip metadata to presence") {
-                    verify { seleniumMockHelper.mock.addToPresence("sip_address", "sip:sipAddress@sip.8x8.vc") }
-                    verify { seleniumMockHelper.mock.sendPresence() }
+                    verify {
+                        seleniumMockHelper.mock.setParticipantProperties(
+                            mapOf("sip_address" to "sip:sipAddress@sip.8x8.vc")
+                        )
+                    }
                 }
                 context("and the pjsua starts successfully") {
                     pjsuaClientMockHelper.startSuccessfully()


### PR DESCRIPTION
This PR implements presence setting in `ExternalAPIPage`, enabling participant properties (session_id, mode, live-stream-view-url, sip_address) to be sent to other participants. It does so by adding a new CallPage interface method `setParticipantProperties` for bulk writes, which the file recording and streaming services use instead of per-key calls.

Depends on: https://github.com/jitsi/jitsi-meet/pull/17639