### PR TITLE
feat(external-api): Query local audio/video mute state

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -218,9 +218,25 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun isVisitor(): Boolean = false
 
-    override fun isLocalAudioMuted(): Boolean = true
+    override fun isLocalAudioMuted(): Boolean {
+        val result = callRecorderApiAsync(
+            "isAudioMuted",
+            """
+            api.isAudioMuted().then(muted => cb(muted === true)).catch(() => cb(false));
+            """
+        ) as? Boolean
+        return result ?: false
+    }
 
-    override fun isLocalVideoMuted(): Boolean = true
+    override fun isLocalVideoMuted(): Boolean {
+        val result = callRecorderApiAsync(
+            "isVideoMuted",
+            """
+            api.isVideoMuted().then(muted => cb(muted === true)).catch(() => cb(false));
+            """
+        ) as? Boolean
+        return result ?: false
+    }
 
     override fun isAudioForceMuted(): Boolean = false
 

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -222,20 +222,20 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         val result = callRecorderApiAsync(
             "isAudioMuted",
             """
-            api.isAudioMuted().then(muted => cb(muted === true)).catch(() => cb(false));
+            api.isAudioMuted().then(muted => cb(muted === true)).catch(() => cb(true));
             """
         ) as? Boolean
-        return result ?: false
+        return result ?: true
     }
 
     override fun isLocalVideoMuted(): Boolean {
         val result = callRecorderApiAsync(
             "isVideoMuted",
             """
-            api.isVideoMuted().then(muted => cb(muted === true)).catch(() => cb(false));
+            api.isVideoMuted().then(muted => cb(muted === true)).catch(() => cb(true));
             """
         ) as? Boolean
-        return result ?: false
+        return result ?: true
     }
 
     override fun isAudioForceMuted(): Boolean = false


### PR DESCRIPTION
Implements `isLocalAudioMuted()` and `isLocalVideoMuted()` in `ExternalAPIPage`, used by the *6/*7 DTMF mute-toggle handlers.