### PR TITLE
feat(external-api): Detect local participant kicked

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -212,7 +212,16 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         return iceConnected
     }
 
-    override fun isLocalParticipantKicked(): Boolean = false
+    override fun isLocalParticipantKicked(): Boolean {
+        return try {
+            driver.executeScript(
+                "return window.jibriPageState.localParticipantKicked === true;"
+            ) as? Boolean ?: false
+        } catch (t: Throwable) {
+            logger.error("Error checking isLocalParticipantKicked", t)
+            false
+        }
+    }
 
     override fun numRemoteParticipantsMuted(): Int = 0
 

--- a/src/main/resources/recorder.html
+++ b/src/main/resources/recorder.html
@@ -72,7 +72,6 @@
 						parentNode: document.querySelector(
 							"#jitsiMeetContainer",
 						),
-
 						configOverwrite: {
 							...(config.config || {}),
 							iAmRecorder: true,
@@ -92,6 +91,7 @@
 						conferenceJoined: false,
 						apiError: null,
 						localParticipantId: null,
+						localParticipantKicked: false,
 					};
 
 					api.addListener("videoConferenceJoined", ({ id }) => {
@@ -101,6 +101,12 @@
 
 					api.addListener("videoConferenceLeft", () => {
 						window.jibriPageState.conferenceJoined = false;
+					});
+
+					api.addListener("participantKickedOut", ({ kicked }) => {
+						if (kicked?.local) {
+							window.jibriPageState.localParticipantKicked = true;
+						}
 					});
 
 					api.addListener("errorOccurred", (error) => {


### PR DESCRIPTION
This PR adds detection so the recorder stops recording when it gets kicked from the room.