### PR TITLE
feat(external-api): Query audio/video force mute state

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -231,15 +231,12 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         val result = callRecorderApiAsync(
             "isParticipantForceMuted",
             """
-            api.getRoomsInfo().then(roomsData => {
-                const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
-                const localId = mainRoom?.participants?.[0]?.id;
-                if (!localId) {
-                    cb(false);
-                    return;
-                }
-                api.isParticipantForceMuted(localId, '$mediaType').then(forceMuted => cb(forceMuted === true)).catch(() => cb(false));
-            }).catch(() => cb(false));
+            const localId = window.jibriPageState?.localParticipantId;
+            if (!localId) {
+                cb(false);
+                return;
+            }
+            api.isParticipantForceMuted(localId, '$mediaType').then(forceMuted => cb(forceMuted === true)).catch(() => cb(false));
             """
         )
         return result as? Boolean ?: false

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -222,9 +222,28 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
 
     override fun isLocalVideoMuted(): Boolean = true
 
-    override fun isAudioForceMuted(): Boolean = false
+    override fun isAudioForceMuted(): Boolean = isForceMuted("audio")
 
-    override fun isVideoForceMuted(): Boolean = false
+    override fun isVideoForceMuted(): Boolean = isForceMuted("video")
+
+    /** Returns true if AV moderation is enabled for [mediaType] and the local participant is not approved to unmute. */
+    private fun isForceMuted(mediaType: String): Boolean {
+        val result = callRecorderApiAsync(
+            "isParticipantForceMuted",
+            """
+            api.getRoomsInfo().then(roomsData => {
+                const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
+                const localId = mainRoom?.participants?.[0]?.id;
+                if (!localId) {
+                    cb(false);
+                    return;
+                }
+                api.isParticipantForceMuted(localId, '$mediaType').then(forceMuted => cb(forceMuted === true)).catch(() => cb(false));
+            }).catch(() => cb(false));
+            """
+        )
+        return result as? Boolean ?: false
+    }
 
     /**
      * Toggles audio/video mute, then polls [isMutedMethod] until it

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -231,7 +231,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         val result = callRecorderApiAsync(
             "isParticipantForceMuted",
             """
-            const localId = window.jibriPageState?.localParticipantId;
+            const localId = window.jibriPageState.localParticipantId;
             if (!localId) {
                 cb(false);
                 return;

--- a/src/main/resources/recorder.html
+++ b/src/main/resources/recorder.html
@@ -91,10 +91,12 @@
 					window.jibriPageState = {
 						conferenceJoined: false,
 						apiError: null,
+						localParticipantId: null,
 					};
 
-					api.addListener("videoConferenceJoined", () => {
+					api.addListener("videoConferenceJoined", ({ id }) => {
 						window.jibriPageState.conferenceJoined = true;
+						window.jibriPageState.localParticipantId = id;
 					});
 
 					api.addListener("videoConferenceLeft", () => {


### PR DESCRIPTION
Implements ExternalAPIPage.isAudioForceMuted()/isVideoForceMuted(), determining if AV moderation is preventing the local participant from unmuting. JibriSelenium's *6/*7 DTMF handlers call them to raise a hand instead of unmuting when force-muted.