### PR TITLE
Add basic tracing for Jibri requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-xmpp-extensions</artifactId>
-            <version>1.0-117-g60c0446</version>
+            <version>1.0-118-g64ecd07</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>jicoco-config</artifactId>
             <version>${jicoco.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -125,7 +119,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-xmpp-extensions</artifactId>
-            <version>1.0-110-g00660c3</version>
+            <version>1.0-117-g60c0446</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>
@@ -181,13 +175,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-metaconfig</artifactId>
-            <version>1.0-11-g8cf950e</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>1.0-12-g02d4bd5</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -197,7 +185,7 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.4.0</version>
+            <version>1.4.2</version>
         </dependency>
         <!-- testing -->
         <dependency>
@@ -278,6 +266,17 @@
             <version>${jicoco.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jicoco-tracing</artifactId>
+            <version>${jicoco.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.48.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -19,6 +19,7 @@ package org.jitsi.jibri.api.xmpp
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.opentelemetry.api.trace.StatusCode
 import org.jitsi.jibri.FileRecordingRequestParams
 import org.jitsi.jibri.JibriBusyException
 import org.jitsi.jibri.JibriManager
@@ -36,7 +37,10 @@ import org.jitsi.jibri.status.ComponentState
 import org.jitsi.jibri.status.JibriStatus
 import org.jitsi.jibri.status.JibriStatusManager
 import org.jitsi.jibri.util.getCallUrlInfoFromJid
+import org.jitsi.tracing.TracingGlobal
 import org.jitsi.utils.logging2.createLogger
+import org.jitsi.xmpp.extensions.TraceParent
+import org.jitsi.xmpp.extensions.TraceParentProvider
 import org.jitsi.xmpp.extensions.jibri.JibriIq
 import org.jitsi.xmpp.extensions.jibri.JibriIqProvider
 import org.jitsi.xmpp.extensions.jibri.JibriStatusPacketExt
@@ -71,6 +75,7 @@ class XmppApi(
     private val jibriStatusManager: JibriStatusManager,
 ) : IQListener {
     private val logger = createLogger()
+    private val tracer = TracingGlobal.sdk.getTracer("org.jitsi.jibri.xmpp")
 
     private val connectionStateListener = object : ConnectionStateListener {
         override fun connected(mucClient: MucClient) {
@@ -135,6 +140,11 @@ class XmppApi(
             JibriIq.ELEMENT,
             JibriIq.NAMESPACE,
             JibriIqProvider()
+        )
+        ProviderManager.addExtensionProvider(
+            TraceParent.ELEMENT,
+            TraceParent.NAMESPACE,
+            TraceParentProvider()
         )
         updatePresence(jibriStatusManager.overallStatus)
         jibriStatusManager.addStatusHandler(::updatePresence)
@@ -356,6 +366,30 @@ class XmppApi(
      * expects
      */
     private fun handleStartService(
+        startIq: JibriIq,
+        xmppEnvironment: XmppEnvironmentConfig,
+        environmentContext: EnvironmentContext,
+        serviceStatusHandler: JibriServiceStatusHandler
+    ) {
+        val span = tracer.spanBuilder("jibri.start")
+            .setParent(org.jitsi.tracing.TracingUtil.remoteContextFromIq(startIq))
+            .setAttribute("room", startIq.room.toString())
+            .setAttribute("session.id", startIq.sessionId)
+            .setAttribute("recording-mode", startIq.recordingMode.toString())
+            .startSpan()
+        try {
+            span.makeCurrent().use {
+                doHandleStartService(startIq, xmppEnvironment, environmentContext, serviceStatusHandler)
+            }
+        } catch (e: Throwable) {
+            span.setStatus(StatusCode.ERROR, e.message ?: "")
+            throw e
+        } finally {
+            span.end()
+        }
+    }
+
+    private fun doHandleStartService(
         startIq: JibriIq,
         xmppEnvironment: XmppEnvironmentConfig,
         environmentContext: EnvironmentContext,

--- a/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
+++ b/src/main/kotlin/org/jitsi/jibri/api/xmpp/XmppApi.kt
@@ -353,10 +353,20 @@ class XmppApi(
      * response with [JibriIq.Status.OFF].
      */
     private fun handleStopJibriIq(stopJibriIq: JibriIq): IQ {
-        jibriManager.stopService()
-        // By this point the service has been fully stopped
-        return stopJibriIq.createResult {
-            status = JibriIq.Status.OFF
+        val span = tracer.spanBuilder("jibri.stop")
+            .setParent(org.jitsi.tracing.TracingUtil.remoteContextFromIq(stopJibriIq))
+            .startSpan()
+        try {
+            jibriManager.stopService()
+            // By this point the service has been fully stopped
+            return stopJibriIq.createResult {
+                status = JibriIq.Status.OFF
+            }
+        } catch (e: Throwable) {
+            span.setStatus(StatusCode.ERROR, e.message ?: "")
+            throw e
+        } finally {
+            span.end()
         }
     }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -197,3 +197,8 @@ jibri {
     ice-connection-timeout = 30 seconds
   }
 }
+
+tracing {
+  enabled = false
+  service-name = "jibri"
+}


### PR DESCRIPTION
This PR adds tracing for the handling of colibri requests.

This PR depends on some changes in:
- jitsi-xmpp-extensions: https://github.com/jitsi/jitsi-xmpp-extensions/pull/146
- jicoco: https://github.com/jitsi/jicoco/pull/240

To test this, the following configuration is required
```conf
tracing {
    enabled = true
    otlp-protocol = "grpc"
    otlp-endpoint = "http://localhost:4317"
}
```

Related to the tracing backend GSoC project: https://summerofcode.withgoogle.com/programs/2026/projects/GseggmSv

