### PR TITLE
feat(external-api): Count hidden participants

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -225,7 +225,22 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         return numJigasiParticipants
     }
 
-    override fun numHiddenParticipants(): Int = 0
+    override fun numHiddenParticipants(): Int {
+        val result = callRecorderApiAsync(
+            "getRoomsInfo",
+            """
+            api.getRoomsInfo(true).then(roomsData => {
+                const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
+                // isJibri is isHidden() || isHiddenFromRecorder()
+                const numHidden = (mainRoom?.participants || []).filter(p => p?.isJibri === true).length;
+                cb(numHidden);
+            }).catch(() => cb(0));
+            """
+        ) as? Number
+        val numHidden = result?.toInt() ?: 0
+        logger.debug("Number of hidden participants: $numHidden")
+        return numHidden
+    }
 
     override fun isIceConnected(): Boolean {
         val result = callRecorderApiAsync(

--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -158,6 +158,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         }
         return success
     }
+
     private fun executeRecorderCommand(command: String, arg: Any? = null): Boolean {
         return try {
             driver.executeScript(
@@ -231,8 +232,7 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
             """
             api.getRoomsInfo(true).then(roomsData => {
                 const mainRoom = (roomsData.rooms || []).find(r => r?.isMainRoom);
-                // isJibri is isHidden() || isHiddenFromRecorder()
-                const numHidden = (mainRoom?.participants || []).filter(p => p?.isJibri === true).length;
+                const numHidden = (mainRoom?.participants || []).filter(p => p?.isHidden === true).length;
                 cb(numHidden);
             }).catch(() => cb(0));
             """


### PR DESCRIPTION
Gets the number of hidden participants via `getRoomsInfo(true)`, counting `isJibri === true` entries.

Depends on: https://github.com/jitsi/jitsi-meet/pull/17692