### PR TITLE
fix(external-api): Local video recordings on Wayland

### DIFF
--- a/doc/local-run/run-jibri-local.sh
+++ b/doc/local-run/run-jibri-local.sh
@@ -119,6 +119,10 @@ jibri {
   }
 
   ffmpeg {
+    input-linux = [
+      "-f", "x11grab",
+      "-i", "${DISPLAY:-:0}",
+    ]
     resolution = "$JIBRI_RECORDING_RESOLUTION"
     audio-source = "$JIBRI_AUDIO_SOURCE"
     audio-device = "$JIBRI_AUDIO_DEVICE"
@@ -126,11 +130,13 @@ jibri {
   }
 
   chrome {
+    display = "${DISPLAY:-:0}"
     flags = [
       "--use-fake-ui-for-media-stream",
       "--enabled",
       "--autoplay-policy=no-user-gesture-required",
-      "--ignore-certificate-errors"
+      "--ignore-certificate-errors",
+      "--ozone-platform=x11" # Force X11, required for x11grab to capture video
     ]
   }
 

--- a/doc/local-run/run-jibri-local.sh
+++ b/doc/local-run/run-jibri-local.sh
@@ -135,7 +135,6 @@ jibri {
   }
 
   chrome {
-    display = "${DISPLAY:-:0}"
     flags = [
       "--use-fake-ui-for-media-stream",
       "--enabled",

--- a/doc/local-run/run-jibri-local.sh
+++ b/doc/local-run/run-jibri-local.sh
@@ -108,6 +108,14 @@ EOG
 )
 fi
 
+FFMPEG_LINUX_OVERRIDES=$(cat <<EOG
+    input-linux = [
+      "-f", "x11grab",
+      "-i", "${DISPLAY:-:0}",
+    ]
+EOG
+)
+
 cat > "$JIBRI_CONF" <<EOF
 jibri {
   id = "$JIBRI_INSTANCE_ID"
@@ -119,14 +127,11 @@ jibri {
   }
 
   ffmpeg {
-    input-linux = [
-      "-f", "x11grab",
-      "-i", "${DISPLAY:-:0}",
-    ]
     resolution = "$JIBRI_RECORDING_RESOLUTION"
     audio-source = "$JIBRI_AUDIO_SOURCE"
     audio-device = "$JIBRI_AUDIO_DEVICE"
     $FFMPEG_MAC_OVERRIDES
+    $FFMPEG_LINUX_OVERRIDES
   }
 
   chrome {

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -35,6 +35,7 @@ import org.jitsi.jibri.util.getLoggerWithHandler
 import org.jitsi.jibri.util.randomAlphaNum
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
+import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.openqa.selenium.TimeoutException
@@ -182,6 +183,8 @@ class JibriSelenium(
     private val stateMachine = SeleniumStateMachine()
     private var shuttingDown = AtomicBoolean(false)
     private val chromeOpts: List<String> by config("jibri.chrome.flags".from(Config.configSource))
+    private val configuredChromeDisplay: String? by optionalconfig("jibri.chrome.display".from(Config.configSource))
+    private val chromeDisplay: String = configuredChromeDisplay ?: jibriSeleniumOptions.display
     private var callPage: CallPage
 
     /**
@@ -205,7 +208,7 @@ class JibriSelenium(
         chromeOptions.addArguments(chromeOpts)
         chromeOptions.addArguments(jibriSeleniumOptions.extraChromeCommandLineFlags)
         val chromeDriverService = ChromeDriverService.Builder()
-            .withEnvironment(mapOf("DISPLAY" to jibriSeleniumOptions.display))
+            .withEnvironment(mapOf("DISPLAY" to chromeDisplay))
             .withLogFile(chromeDriverLogFile)
             .build()
         val logPrefs = LoggingPreferences()

--- a/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/JibriSelenium.kt
@@ -35,7 +35,6 @@ import org.jitsi.jibri.util.getLoggerWithHandler
 import org.jitsi.jibri.util.randomAlphaNum
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
-import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.openqa.selenium.TimeoutException
@@ -104,7 +103,7 @@ data class JibriSeleniumOptions(
     /**
      * Which display selenium should be started on
      */
-    val display: String = ":0",
+    val display: String = System.getenv("DISPLAY") ?: ":0",
     /**
      * The display name that should be used for jibri.  Note that this
      * is currently only used in the sipgateway gateway scenario; when doing
@@ -183,8 +182,6 @@ class JibriSelenium(
     private val stateMachine = SeleniumStateMachine()
     private var shuttingDown = AtomicBoolean(false)
     private val chromeOpts: List<String> by config("jibri.chrome.flags".from(Config.configSource))
-    private val configuredChromeDisplay: String? by optionalconfig("jibri.chrome.display".from(Config.configSource))
-    private val chromeDisplay: String = configuredChromeDisplay ?: jibriSeleniumOptions.display
     private var callPage: CallPage
 
     /**
@@ -208,7 +205,7 @@ class JibriSelenium(
         chromeOptions.addArguments(chromeOpts)
         chromeOptions.addArguments(jibriSeleniumOptions.extraChromeCommandLineFlags)
         val chromeDriverService = ChromeDriverService.Builder()
-            .withEnvironment(mapOf("DISPLAY" to chromeDisplay))
+            .withEnvironment(mapOf("DISPLAY" to jibriSeleniumOptions.display))
             .withLogFile(chromeDriverLogFile)
             .build()
         val logPrefs = LoggingPreferences()


### PR DESCRIPTION
Local recordings on Wayland contained no visible video: Chrome rendered on the wrong display, invisible to ffmpeg's `x11grab`

Changes:
- `JibriSelenium.kt`: if set, uses the `DISPLAY` env var.
- `run-jibri-local.sh`: forces `--ozone-platform=x11` so Chrome can't fall back to native Wayland rendering.