### PR TITLE
fix(external-api): Derive tenant from baseUrl path when empty

### DIFF
--- a/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
+++ b/src/main/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPage.kt
@@ -8,6 +8,7 @@ import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.support.PageFactory
 import org.openqa.selenium.support.ui.WebDriverWait
 import java.io.File
+import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
@@ -35,8 +36,13 @@ class ExternalAPIPage(driver: RemoteWebDriver) : AbstractPageObject(driver), Cal
         // external_api.js from the deployment (the page itself is loaded from a
         // local file and has no deployment origin of its own).
         val baseUrl = url.baseUrl
-        // Convert tenant dots to slashes for URL path format.
-        val tenantPath = if (url.tenant.isNotEmpty()) url.tenant.replace(".", "/") else ""
+        // `tenant` is only set explicitly for XMPP-invited joins; other callers (e.g. the
+        // HTTP startService API) only set baseUrl/callName, so fall back to baseUrl's path.
+        val tenantPath = if (url.tenant.isNotEmpty()) {
+            url.tenant.replace(".", "/")
+        } else {
+            URI(baseUrl).path.trim('/')
+        }
         val recorderUrl = buildString {
             append(recorderHtmlFile.toURI().toString())
             append("?room=").append(encode(room))

--- a/src/test/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPageTest.kt
+++ b/src/test/kotlin/org/jitsi/jibri/selenium/pageobjects/ExternalAPIPageTest.kt
@@ -60,6 +60,19 @@ internal class ExternalAPIPageTest : ShouldSpec() {
             }
         }
 
+        should("derive tenant from baseUrl path when tenant is not explicitly set") {
+            // The HTTP startService API only sets baseUrl/callName, leaving tenant empty
+            // even when baseUrl's path carries the tenant segment.
+            val urlSlot = slot<String>()
+            every { driver.get(capture(urlSlot)) } returns Unit
+            every { driver.executeScript("return window.jibriPageState?.apiError;") } returns null
+            every { driver.executeScript("return window.jibriPageState?.conferenceJoined === true;") } returns true
+
+            page.visit(CallUrlInfo("https://meet.example.com/tenant-test", "room-test", "")) shouldBe true
+            urlSlot.captured.shouldContain("room=room-test")
+            urlSlot.captured.shouldContain("tenant=tenant-test")
+        }
+
         should("return false if apiError occurs") {
             val t = table(
                 headers("errorAtCall", "scenario"),


### PR DESCRIPTION
## Description

`ExternalAPIPage` only read the tenant from `CallUrlInfo.tenant`, which stays empty when
triggered via the HTTP `startService` API. Jibri resolved to the wrong room and failed to join.
Derive it from `baseUrl`'s path instead when empty.

## Changes

- `ExternalAPIPage.visit()`: Derive tenant from `baseUrl`'s path when empty
- `ExternalAPIPageTest`: Add test for the new case